### PR TITLE
Use cors-anywhere for cors-proxy endpoint.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3672,6 +3672,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors-anywhere": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cors-anywhere/-/cors-anywhere-0.4.1.tgz",
+      "integrity": "sha512-UKK0g2uT63x3hvyU1jjdSOPY4zIOB0iXveA7puYm8QIprQ1KVQQEFVbDHg5q02c5uAEYy+yY2Ic0RAC45dF2Ag==",
+      "requires": {
+        "http-proxy": "1.11.1",
+        "proxy-from-env": "0.0.1"
+      }
+    },
     "cosmiconfig": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.5.tgz",
@@ -6414,6 +6423,22 @@
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
         "statuses": ">= 1.4.0 < 2"
+      }
+    },
+    "http-proxy": {
+      "version": "1.11.1",
+      "resolved": "http://registry.npmjs.org/http-proxy/-/http-proxy-1.11.1.tgz",
+      "integrity": "sha1-cd9VdX6ALVjqgQ3yJEAZ3aBa6F0=",
+      "requires": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "0.x.x"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+          "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
+        }
       }
     },
     "https-browserify": {
@@ -10909,6 +10934,11 @@
         "object-assign": "^4.1.1"
       }
     },
+    "proxy-from-env": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-0.0.1.tgz",
+      "integrity": "sha1-snxJRunm1dutt1mKZDXTAUxM/Uk="
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -11894,6 +11924,11 @@
         "caller-path": "^0.1.0",
         "resolve-from": "^1.0.0"
       }
+    },
+    "requires-port": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-0.0.1.tgz",
+      "integrity": "sha1-S0QUQR2d98hVmV3YmajHiilRwW0="
     },
     "resolve-cwd": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "chokidar": "^2.0.4",
     "classnames": "^2.2.5",
     "commander": "^2.15.1",
+    "cors-anywhere": "^0.4.1",
     "env-paths": "^1.0.0",
     "eventemitter3": "^3.1.0",
     "fast-deep-equal": "^2.0.1",

--- a/src/client/api/Project.js
+++ b/src/client/api/Project.js
@@ -35,9 +35,7 @@ async function resolveUrl(url, index) {
 }
 
 function proxiedUrlFor(url) {
-  const proxiedUrl = new URL(`/api/cors-proxy`, window.location);
-  proxiedUrl.searchParams.set("url", url);
-  return proxiedUrl.href;
+  return new URL(`/api/cors-proxy/${url}`, window.location).href;
 }
 
 function getFilesFromSketchfabZip(src) {


### PR DESCRIPTION
The existing cors-proxy endpoint didn't work with some assets. Rather than reimplementing `cors-anywhere` I've embedded it into Spoke's server. It needs a bit of a hack because it isn't compatible with Koa, but it works.