### PR TITLE
Improves how heightfields are generated and fixes various issues.

### DIFF
--- a/src/editor/heightfield/HeightfieldClient.js
+++ b/src/editor/heightfield/HeightfieldClient.js
@@ -6,7 +6,7 @@ export default class HeightfieldClient {
     this.working = false;
   }
 
-  async buildHeightfield(verts, params, signal) {
+  async buildHeightfield(geometry, params, signal) {
     if (this.working) {
       throw new Error("Already building heightfield");
     }
@@ -49,6 +49,8 @@ export default class HeightfieldClient {
       this.worker.addEventListener("error", onError);
     });
 
+    const verts = geometry.attributes.position.array;
+
     this.worker.postMessage(
       {
         verts,
@@ -62,6 +64,6 @@ export default class HeightfieldClient {
       throw new Error(result.error);
     }
 
-    return { heightfield: result.heightfield };
+    return result.heightfield;
   }
 }

--- a/src/editor/heightfield/HeightfieldClient.js
+++ b/src/editor/heightfield/HeightfieldClient.js
@@ -1,0 +1,67 @@
+import HeightfieldWorker from "./heightfield.worker";
+
+export default class HeightfieldClient {
+  constructor() {
+    this.worker = new HeightfieldWorker();
+    this.working = false;
+  }
+
+  async buildHeightfield(verts, params, signal) {
+    if (this.working) {
+      throw new Error("Already building heightfield");
+    }
+
+    this.working = true;
+
+    const heightfieldPromise = new Promise((resolve, reject) => {
+      let onMessage = null;
+      let onError = null;
+      let onAbort = null;
+
+      const cleanUp = () => {
+        signal.removeEventListener("abort", onAbort);
+        this.worker.removeEventListener("message", onMessage);
+        this.worker.removeEventListener("message", onError);
+        this.working = false;
+      };
+
+      onMessage = event => {
+        resolve(event.data);
+        cleanUp();
+      };
+
+      onAbort = () => {
+        this.worker.terminate();
+        this.worker = new HeightfieldWorker();
+        const error = new Error("Canceled heightfield generation.");
+        error.aborted = true;
+        reject(error);
+        cleanUp();
+      };
+
+      onError = error => {
+        reject(error);
+        cleanUp();
+      };
+
+      signal.addEventListener("abort", onAbort);
+      this.worker.addEventListener("message", onMessage);
+      this.worker.addEventListener("error", onError);
+    });
+
+    this.worker.postMessage(
+      {
+        verts,
+        params
+      },
+      [verts.buffer]
+    );
+    const result = await heightfieldPromise;
+
+    if (result.error) {
+      throw new Error(result.error);
+    }
+
+    return { heightfield: result.heightfield };
+  }
+}

--- a/src/editor/heightfield/heightfield.worker.js
+++ b/src/editor/heightfield/heightfield.worker.js
@@ -1,0 +1,101 @@
+import * as THREE from "three";
+import { MeshBVH, acceleratedRaycast } from "three-mesh-bvh";
+
+THREE.Mesh.prototype.raycast = acceleratedRaycast;
+
+function generateHeightfield(geometry, params) {
+  geometry.computeBoundingBox();
+  const size = new THREE.Vector3();
+  geometry.boundingBox.getSize(size);
+
+  const bvh = new MeshBVH(geometry);
+
+  const heightfieldMesh = new THREE.Mesh(geometry);
+
+  const maxSide = Math.max(size.x, size.z);
+  const distance = params.hasOwnProperty("distance") ? params.distance : Math.max(0.25, Math.pow(maxSide, 1 / 2) / 10);
+  const resolution = Math.ceil(maxSide / distance);
+
+  const data = [];
+
+  const offset = new THREE.Vector3();
+  geometry.boundingBox.getCenter(offset);
+
+  const down = new THREE.Vector3(0, -1, 0);
+  const position = new THREE.Vector3();
+  const raycaster = new THREE.Raycaster();
+
+  const offsetX = -size.x / 2 + offset.x;
+  const offsetZ = -size.z / 2 + offset.z;
+
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  for (let z = 0; z < resolution; z++) {
+    data[z] = [];
+    for (let x = 0; x < resolution; x++) {
+      position.set(offsetX + x * distance, params.raycastY, offsetZ + z * distance);
+      raycaster.set(position, down);
+
+      const hits = [];
+      bvh.raycast(heightfieldMesh, raycaster, raycaster.ray, hits);
+      let hit;
+
+      if (hits.length === 1) {
+        hit = hits[0];
+      } else {
+        for (let i = 0; i < hits.length; i++) {
+          if ((!hit || hits[i].distance < hit.distance) && hits[i].point.y < params.minY + params.agentHeight) {
+            hit = hits[i];
+          }
+        }
+      }
+
+      if (!hit && hits.length > 0) {
+        hit = hits[0];
+      }
+
+      let val;
+
+      if (hit) {
+        val = hit.point.y;
+      } else {
+        val = params.minY;
+      }
+
+      data[z][x] = val;
+
+      if (val < min) {
+        min = data[z][x];
+      }
+      if (val > max) {
+        max = data[z][x];
+      }
+    }
+  }
+
+  if (data.length === 0) {
+    return null;
+  }
+
+  offset.y = (max - min) / 2; //Bullet expect this to be the center between the max and min heights.
+
+  return { offset, distance, data, width: size.x, length: size.z };
+}
+
+const defaultParams = {
+  raycastY: 1000,
+  minY: 0,
+  agentHeight: 1.7
+};
+
+self.onmessage = async event => {
+  const message = event.data;
+
+  const params = Object.assign({}, defaultParams, message.params || {});
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.addAttribute("position", new THREE.Float32BufferAttribute(message.verts, 3));
+  const heightfield = generateHeightfield(geometry, params);
+
+  self.postMessage({ heightfield });
+};

--- a/src/editor/objects/FloorPlan.js
+++ b/src/editor/objects/FloorPlan.js
@@ -14,25 +14,17 @@ export default class FloorPlan extends THREE.Object3D {
       this.remove(this.navMesh);
     }
 
+    this.navMesh = object;
+
     if (object) {
       this.add(object);
+      this.navMesh.layers.set(1);
+      this.navMesh.visible = false;
     }
-
-    this.navMesh = object;
-    this.navMesh.layers.set(1);
   }
 
-  setHeightfieldMesh(object) {
-    if (this.heightfieldMesh) {
-      this.remove(this.heightfieldMesh);
-    }
-
-    if (object) {
-      this.add(object);
-    }
-
-    this.heightfieldMesh = object;
-    this.heightfieldMesh.layers.set(1);
+  setHeightfield(heightfield) {
+    this.heightfield = heightfield || null;
   }
 
   copy(source, recursive) {
@@ -47,8 +39,6 @@ export default class FloorPlan extends THREE.Object3D {
         clonedChild = child.clone();
         clonedChild.material = child.material.clone();
         this.navMesh = clonedChild;
-      } else if (child === source.heightfieldMesh) {
-        //dont clone the heightfieldMesh
       } else if (recursive === true) {
         clonedChild = child.clone();
       }

--- a/src/editor/objects/FloorPlan.js
+++ b/src/editor/objects/FloorPlan.js
@@ -6,6 +6,7 @@ export default class FloorPlan extends THREE.Object3D {
     this.position.y = 0.005;
     this.navMesh = null;
     this.heightfield = null;
+    this.heightfieldMesh = null;
   }
 
   setNavMesh(object) {
@@ -21,6 +22,19 @@ export default class FloorPlan extends THREE.Object3D {
     this.navMesh.layers.set(1);
   }
 
+  setHeightfieldMesh(object) {
+    if (this.heightfieldMesh) {
+      this.remove(this.heightfieldMesh);
+    }
+
+    if (object) {
+      this.add(object);
+    }
+
+    this.heightfieldMesh = object;
+    this.heightfieldMesh.layers.set(1);
+  }
+
   copy(source, recursive) {
     super.copy(source, false);
 
@@ -33,6 +47,8 @@ export default class FloorPlan extends THREE.Object3D {
         clonedChild = child.clone();
         clonedChild.material = child.material.clone();
         this.navMesh = clonedChild;
+      } else if (child === source.heightfieldMesh) {
+        //dont clone the heightfieldMesh
       } else if (recursive === true) {
         clonedChild = child.clone();
       }

--- a/src/editor/recast/RecastClient.js
+++ b/src/editor/recast/RecastClient.js
@@ -25,12 +25,23 @@ export default class RecastClient {
     this.working = false;
   }
 
-  async buildNavMesh(verts, faces, params, signal) {
+  async buildNavMesh(geometry, params, signal) {
     if (this.working) {
       throw new Error("Already building nav mesh");
     }
 
     this.working = true;
+
+    if (geometry.attributes.position.count === 0) {
+      this.working = false;
+      return geometry;
+    }
+
+    const verts = geometry.attributes.position.array;
+    const faces = new Int32Array(verts.length / 3);
+    for (let i = 0; i < faces.length; i++) {
+      faces[i] = i;
+    }
 
     const navMeshPromise = new Promise((resolve, reject) => {
       let onMessage = null;
@@ -83,10 +94,10 @@ export default class RecastClient {
       throw new Error(statuses[result.status] || result.error);
     }
 
-    const geometry = new THREE.BufferGeometry();
-    geometry.addAttribute("position", new THREE.Float32BufferAttribute(result.verts, 3));
-    geometry.setIndex(new THREE.Uint16BufferAttribute(result.indices, 1));
+    const navmesh = new THREE.BufferGeometry();
+    navmesh.addAttribute("position", new THREE.Float32BufferAttribute(result.verts, 3));
+    navmesh.setIndex(new THREE.Uint16BufferAttribute(result.indices, 1));
 
-    return { navmesh: geometry };
+    return navmesh;
   }
 }

--- a/src/editor/recast/RecastClient.js
+++ b/src/editor/recast/RecastClient.js
@@ -25,7 +25,7 @@ export default class RecastClient {
     this.working = false;
   }
 
-  async buildNavMesh(verts, faces, params, generateHeightfield, signal) {
+  async buildNavMesh(verts, faces, params, signal) {
     if (this.working) {
       throw new Error("Already building nav mesh");
     }
@@ -72,8 +72,7 @@ export default class RecastClient {
       {
         verts,
         faces,
-        params,
-        generateHeightfield
+        params
       },
       [verts.buffer, faces.buffer]
     );
@@ -88,6 +87,6 @@ export default class RecastClient {
     geometry.addAttribute("position", new THREE.Float32BufferAttribute(result.verts, 3));
     geometry.setIndex(new THREE.Uint16BufferAttribute(result.indices, 1));
 
-    return { navmesh: geometry, heightfield: result.heightfield };
+    return { navmesh: geometry };
   }
 }

--- a/src/editor/recast/recast.worker.js
+++ b/src/editor/recast/recast.worker.js
@@ -1,72 +1,5 @@
 import Recast from "recast-wasm/dist/recast.js";
 import recastWasmUrl from "recast-wasm/dist/recast.wasm";
-import * as THREE from "three";
-import { MeshBVH, acceleratedRaycast } from "three-mesh-bvh";
-
-THREE.Mesh.prototype.raycast = acceleratedRaycast;
-
-function generateHeightfield(geometry) {
-  geometry.computeBoundingBox();
-  const size = new THREE.Vector3();
-  geometry.boundingBox.getSize(size);
-
-  const bvh = new MeshBVH(geometry);
-
-  const heightfieldMesh = new THREE.Mesh(geometry);
-
-  const maxSide = Math.max(size.x, size.z);
-  const distance = Math.max(0.25, Math.pow(maxSide, 1 / 2) / 10);
-  const resolution = Math.ceil(maxSide / distance);
-
-  const data = [];
-
-  const down = new THREE.Vector3(0, -1, 0);
-  const position = new THREE.Vector3();
-  const raycaster = new THREE.Raycaster();
-
-  const offsetX = -size.x / 2;
-  const offsetZ = -size.z / 2;
-
-  let min = Infinity;
-  for (let z = 0; z < resolution; z++) {
-    data[z] = [];
-    for (let x = 0; x < resolution; x++) {
-      position.set(offsetX + x * distance, size.y / 2, offsetZ + z * distance);
-      raycaster.set(position, down);
-
-      const hit = bvh.raycastFirst(heightfieldMesh, raycaster, raycaster.ray);
-
-      let val;
-
-      if (hit) {
-        val = -hit.distance + size.y / 2;
-      } else {
-        val = -size.y / 2;
-      }
-
-      data[z][x] = val;
-
-      if (val < min) {
-        min = data[z][x];
-      }
-    }
-  }
-
-  const offset = new THREE.Vector3(-size.x / 2, min, -size.z / 2);
-
-  // Cannon.js will be consuming this data and it doesn't like heightfields with negative heights.
-  for (let z = 0; z < resolution; z++) {
-    for (let x = 0; x < resolution; x++) {
-      data[z][x] -= min;
-    }
-  }
-
-  if (data.length === 0) {
-    return null;
-  }
-
-  return { offset, distance, data };
-}
 
 const defaultParams = {
   cellSize: 0.166,
@@ -176,21 +109,10 @@ self.onmessage = async event => {
         indices[index++] = c;
       }
     }
-
-    let heightfield = null;
-
-    if (message.generateHeightfield) {
-      const geometry = new THREE.BufferGeometry();
-      geometry.addAttribute("position", new THREE.Float32BufferAttribute(verts, 3));
-      geometry.setIndex(new THREE.Uint16BufferAttribute(indices, 1));
-      heightfield = generateHeightfield(geometry);
-    }
-
     self.postMessage(
       {
         indices,
-        verts,
-        heightfield
+        verts
       },
       [indices.buffer, verts.buffer]
     );

--- a/src/editor/utils/cloneObject3D.js
+++ b/src/editor/utils/cloneObject3D.js
@@ -21,6 +21,10 @@ export default function cloneObject3D(source, preserveUUIDs) {
   source.traverse(function(curNode) {
     const clonedNode = cloneLookup.get(curNode);
 
+    if (!clonedNode) {
+      return;
+    }
+
     if (curNode.animations) {
       clonedNode.animations = curNode.animations;
     }

--- a/src/editor/utils/mergeMeshGeometries.js
+++ b/src/editor/utils/mergeMeshGeometries.js
@@ -1,5 +1,12 @@
 import THREE from "../../vendor/three";
 
+function createEmptyGeometry() {
+  const emptyGeometry = new THREE.BufferGeometry();
+  emptyGeometry.setIndex([]);
+  emptyGeometry.addAttribute("position", new THREE.Float32BufferAttribute([], 3));
+  return emptyGeometry;
+}
+
 export default function mergeMeshGeometries(meshes) {
   const geometries = [];
 
@@ -12,7 +19,13 @@ export default function mergeMeshGeometries(meshes) {
       attributes = geometry.attributes;
     }
 
-    if (!attributes.position || attributes.position.itemSize !== 3) return;
+    if (!attributes.position) {
+      continue;
+    }
+
+    if (attributes.position.itemSize !== 3) {
+      throw new Error("Tried to merge geometry with an invalid number of positions");
+    }
 
     if (geometry.index) geometry = geometry.toNonIndexed();
 
@@ -26,7 +39,7 @@ export default function mergeMeshGeometries(meshes) {
   }
 
   if (geometries.length === 0) {
-    return new THREE.BufferGeometry();
+    return createEmptyGeometry();
   }
 
   const geometry = THREE.BufferGeometryUtils.mergeBufferGeometries(geometries);


### PR DESCRIPTION
Added a couple fixes to @InfiniteLee's PR #624 

- Separates heightfield code into its own worker.
- Heightfields take into account spawner positions to try to determine what surfaces to exclude (e.g. ceilings).
- The navmesh is no longer used to generate the heightfield, instead the collideable geometry is used directly.
- Heightfields are generated with `raycast` instead of `raycastFirst` because `raycastFirst` only returns the first face found in the BVH, not necessarily the first intersected face. This is slower but gives very accurate results.
- The raycaster y position is set to `[large number]` (currently 1000) and uses the point.y value instead of the distance value to determine hit locations. 
- The offset value returned is updated to work with Bullet's heightmap shape. 
- Adds visual rendering in spoke so you can preview the output.
![heightfield](https://user-images.githubusercontent.com/1821537/57495844-d9647600-7284-11e9-87a9-c26a8a9825af.jpg)
