### PR TITLE
Use acceleratedRaycast correctly

### DIFF
--- a/src/editor/heightfield/heightfield.worker.js
+++ b/src/editor/heightfield/heightfield.worker.js
@@ -37,7 +37,7 @@ function generateHeightfield(geometry, params) {
       raycaster.set(position, down);
 
       const hits = [];
-      bvh.raycast(heightfieldMesh, raycaster, raycaster.ray, hits);
+      heightfieldMesh.raycast(raycaster, hits);
       let hit;
 
       if (hits.length === 1) {


### PR DESCRIPTION
use the "correct" raycast method, as set by `THREE.Mesh.prototype.raycast = acceleratedRaycast;`

This version ensures the raycaster and the mesh are using the same coordinate space.