### PR TITLE
Fixes for heightfield generation

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -296,7 +296,7 @@ export default class Editor {
     }
 
     json.extensions.MOZ_hubs_components = {
-      version: 1
+      version: 2
     };
 
     json.asset.generator = `Mozilla Spoke ${process.env.BUILD_VERSION}`;

--- a/src/editor/heightfield/heightfield.worker.js
+++ b/src/editor/heightfield/heightfield.worker.js
@@ -1,14 +1,15 @@
 import * as THREE from "three";
-import { MeshBVH, acceleratedRaycast } from "three-mesh-bvh";
+import { MeshBVH, acceleratedRaycast, computeBoundsTree } from "three-mesh-bvh";
 
 THREE.Mesh.prototype.raycast = acceleratedRaycast;
+THREE.BufferGeometry.prototype.computeBoundsTree = computeBoundsTree;
 
 function generateHeightfield(geometry, params) {
   geometry.computeBoundingBox();
   const size = new THREE.Vector3();
   geometry.boundingBox.getSize(size);
 
-  const bvh = new MeshBVH(geometry);
+  geometry.computeBoundsTree();
 
   const heightfieldMesh = new THREE.Mesh(geometry);
 
@@ -25,8 +26,8 @@ function generateHeightfield(geometry, params) {
   const position = new THREE.Vector3();
   const raycaster = new THREE.Raycaster();
 
-  const offsetX = -size.x / 2 + offset.x;
-  const offsetZ = -size.z / 2 + offset.z;
+  const offsetX = -maxSide / 2 + offset.x;
+  const offsetZ = -maxSide / 2 + offset.z;
 
   let min = Number.POSITIVE_INFINITY;
   let max = Number.NEGATIVE_INFINITY;
@@ -79,7 +80,7 @@ function generateHeightfield(geometry, params) {
 
   offset.y = (max + min) / 2; //Bullet expect this to be the center between the max and min heights.
 
-  return { offset, distance, data, width: size.x, length: size.z };
+  return { offset, distance, data, width: maxSide, length: maxSide };
 }
 
 const defaultParams = {


### PR DESCRIPTION
- use the "computeBounds" method to generate the BVH. Without doing this, the bvh is not actually being used.
- raycast in a perfect grid (using maxSide instead of size.x and size.z) because we only use a single "distance" value (as opposed to a distance value for x and z separately). This caused the mesh to be improperly "walked" along the shorter of the two axis. This is causing bad heightfields in scenes with a non square bounding box for its collidable geometry (e.g. atrium and nightclub)