### PR TITLE
Add guard around removeChild in portal unmount

### DIFF
--- a/src/ui/layout/Portal.js
+++ b/src/ui/layout/Portal.js
@@ -17,7 +17,9 @@ export default class Portal extends Component {
   }
 
   componentWillUnmount() {
-    document.body.removeChild(this.el);
+    if (this.el) {
+      document.body.removeChild(this.el);
+    }
   }
 
   render() {


### PR DESCRIPTION
Fixes a long standing bug:

```
NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
```