### PR TITLE
Alternate Render Modes / Grid Toggle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ aliases:
   - &defaults
     working_directory: ~/repo
     docker:
-      - image: circleci/node:12-browsers
+      - image: circleci/node:12.10-browsers
 
 jobs:
   build_and_test:

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -9,7 +9,8 @@ import {
   AudioListener,
   Raycaster,
   Clock,
-  Color
+  Color,
+  Scene
 } from "three";
 import { GLTFExporter } from "./gltf/GLTFExporter";
 import { GLTFLoader } from "./gltf/GLTFLoader";
@@ -143,7 +144,10 @@ export default class Editor extends EventEmitter {
     this.camera.layers.enable(1);
     this.camera.name = "Camera";
 
+    this.helperScene = new Scene();
+
     this.grid = new SpokeInfiniteGridHelper();
+    this.helperScene.add(this.grid);
 
     this.nodes = [this.scene];
 
@@ -235,8 +239,6 @@ export default class Editor extends EventEmitter {
     this.camera.position.set(0, 5, 10);
     this.camera.lookAt(new Vector3());
     this.scene.add(this.camera);
-
-    this.scene.add(this.grid);
 
     this.spokeControls.center.set(0, 0, 0);
     this.spokeControls.onSceneSet(scene);

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -513,8 +513,10 @@ export default class Editor extends EventEmitter {
       this.scene.updateMatrixWorld();
       this.inputManager.update(delta, time);
 
+      const enableShadows = this.renderer.renderMode.enableShadows;
+
       this.scene.traverse(node => {
-        if (node.isDirectionalLight) {
+        if (enableShadows && node.isDirectionalLight) {
           resizeShadowCameraFrustum(node, this.scene);
         }
 

--- a/src/editor/controls/SpokeControls.js
+++ b/src/editor/controls/SpokeControls.js
@@ -89,6 +89,7 @@ export default class SpokeControls extends EventEmitter {
     this.sphere = new Sphere();
 
     this.transformGizmo = new TransformGizmo();
+    this.editor.helperScene.add(this.transformGizmo);
 
     this.transformMode = TransformMode.Translate;
     this.transformSpace = TransformSpace.World;
@@ -137,7 +138,6 @@ export default class SpokeControls extends EventEmitter {
 
   onSceneSet = scene => {
     this.scene = scene;
-    this.scene.add(this.transformGizmo);
   };
 
   onSelectionChanged = () => {

--- a/src/editor/objects/Model.js
+++ b/src/editor/objects/Model.js
@@ -161,6 +161,27 @@ export default class Model extends Object3D {
     }
   }
 
+  setShadowsEnabled(enabled) {
+    if (this.model) {
+      this.model.traverse(child => {
+        child.castShadow = enabled ? this._castShadow : false;
+        child.receiveShadow = enabled ? this._receiveShadow : false;
+
+        if (child.material) {
+          const material = child.material;
+
+          if (Array.isArray(material)) {
+            for (let i = 0; i < material.length; i++) {
+              material[i].needsUpdate = true;
+            }
+          } else {
+            material.needsUpdate = true;
+          }
+        }
+      });
+    }
+  }
+
   // TODO: Add play/pause methods for previewing animations.
 
   copy(source, recursive = true) {

--- a/src/ui/inputs/SelectInput.js
+++ b/src/ui/inputs/SelectInput.js
@@ -57,7 +57,7 @@ const staticStyle = {
   })
 };
 
-export default function SelectInput({ value, options, onChange, placeholder, disabled, error, ...rest }) {
+export default function SelectInput({ value, options, onChange, placeholder, disabled, error, styles, ...rest }) {
   const selectedOption =
     options.find(o => {
       if (o === null) {
@@ -74,7 +74,8 @@ export default function SelectInput({ value, options, onChange, placeholder, dis
     placeholder: (base, { isDisabled }) => ({
       ...base,
       color: isDisabled ? "grey" : error ? "red" : "white"
-    })
+    }),
+    ...styles
   };
 
   return (
@@ -106,6 +107,7 @@ SelectInput.propTypes = {
       label: PropTypes.string
     })
   ),
+  styles: PropTypes.object,
   onChange: PropTypes.func,
   placeholder: PropTypes.string,
   error: PropTypes.bool,

--- a/src/ui/layout/Panel.js
+++ b/src/ui/layout/Panel.js
@@ -38,11 +38,12 @@ export default class Panel extends Component {
   static propTypes = {
     icon: PropTypes.object,
     title: PropTypes.string,
-    children: PropTypes.node
+    children: PropTypes.node,
+    toolbarContent: PropTypes.node
   };
 
   render() {
-    const { icon, title, children, ...rest } = this.props;
+    const { icon, title, children, toolbarContent, ...rest } = this.props;
 
     // .toolbar used for onboarding
 
@@ -51,6 +52,7 @@ export default class Panel extends Component {
         <PanelToolbar className="toolbar">
           {icon && <PanelIcon as={icon} size={12} />}
           <PanelTitle>{title}</PanelTitle>
+          {toolbarContent}
         </PanelToolbar>
         <PanelContent>{children}</PanelContent>
       </PanelContainer>


### PR DESCRIPTION
You can now disable rendering shadows and render in wireframe and normals mode. Disabling helps improve performance while editing complex scenes. You can also now toggle the grid visibility.

![RenderModes](https://user-images.githubusercontent.com/1753624/66333396-bd283c00-e8eb-11e9-8d30-715ceea62616.gif)
