### PR TITLE
Unlit Batching Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "dependencies": {
     "@babel/runtime": "^7.6.0",
     "@mozillareality/easing-functions": "^0.1.1",
+    "@mozillareality/three-batch-manager": "^0.1.4",
     "@mozillareality/three-particle-emitter": "^0.1.5",
     "@sentry/browser": "^5.6.3",
     "abortcontroller-polyfill": "^1.3.0",

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -229,10 +229,12 @@ export default class Editor extends EventEmitter {
     this.removeObject(this.scene);
 
     this.sceneLoading = true;
+    this.disableUpdate = true;
 
     const scene = await SceneNode.loadProject(this, json);
 
     this.sceneLoading = false;
+    this.disableUpdate = false;
     this.scene = scene;
     this.sceneUrl = null;
 
@@ -244,13 +246,13 @@ export default class Editor extends EventEmitter {
     this.spokeControls.onSceneSet(scene);
     scene.background = new Color(0xaaaaaa);
 
+    this.renderer.onSceneSet();
+
     this.addObject(this.scene);
 
     this.deselectAll();
 
     this.history.clear();
-
-    this.renderer.onSceneSet();
 
     this.sceneModified = false;
 

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1785,4 +1785,9 @@ export default class Editor extends EventEmitter {
     this.grid.visible = !this.grid.visible;
     this.emit("gridVisibilityChanged", this.grid.visible);
   }
+
+  dispose() {
+    this.clearCaches();
+    this.renderer.dispose();
+  }
 }

--- a/src/editor/controls/SpokeControls.js
+++ b/src/editor/controls/SpokeControls.js
@@ -98,6 +98,7 @@ export default class SpokeControls extends EventEmitter {
     this.centerViewportPosition = new Vector2();
     this.raycastIgnoreLayers = new Layers();
     this.raycastIgnoreLayers.set(1);
+    this.renderableLayers = new Layers();
 
     this.transformGizmo = new TransformGizmo();
     this.editor.helperScene.add(this.transformGizmo);
@@ -720,7 +721,8 @@ export default class SpokeControls extends EventEmitter {
   _raycastRecursive(object, excludeObjects, excludeLayers) {
     if (
       (excludeObjects && excludeObjects.indexOf(object) !== -1) ||
-      (excludeLayers && excludeLayers.test(object.layers))
+      (excludeLayers && excludeLayers.test(object.layers)) ||
+      this.editor.renderer.batchManager.batches.indexOf(object) !== -1
     ) {
       return;
     }

--- a/src/editor/nodes/KitPieceNode.js
+++ b/src/editor/nodes/KitPieceNode.js
@@ -112,7 +112,15 @@ export default class KitPieceNode extends EditorNodeMixin(Model) {
       try {
         const { accessibleUrl, files } = await this.editor.api.resolveMedia(src);
 
+        if (this.model) {
+          this.editor.renderer.removeBatchedObject(this.model);
+        }
+
         await super.load(accessibleUrl, nextPieceId);
+
+        if (this.model) {
+          this.editor.renderer.addBatchedObject(this.model);
+        }
 
         if (this.model) {
           this.model.position.set(0, 0, 0);
@@ -152,6 +160,18 @@ export default class KitPieceNode extends EditorNodeMixin(Model) {
     this.receiveShadow = true;
 
     return this;
+  }
+
+  onAdd() {
+    if (this.model) {
+      this.editor.renderer.addBatchedObject(this.model);
+    }
+  }
+
+  onRemove() {
+    if (this.model) {
+      this.editor.renderer.removeBatchedObject(this.model);
+    }
   }
 
   updateStaticModes() {

--- a/src/editor/nodes/ModelNode.js
+++ b/src/editor/nodes/ModelNode.js
@@ -122,7 +122,15 @@ export default class ModelNode extends EditorNodeMixin(Model) {
     try {
       const { accessibleUrl, files } = await this.editor.api.resolveMedia(src);
 
+      if (this.model) {
+        this.editor.renderer.removeBatchedObject(this.model);
+      }
+
       await super.load(accessibleUrl);
+
+      if (this.model) {
+        this.editor.renderer.addBatchedObject(this.model);
+      }
 
       if (this.scaleToFit) {
         this.scale.set(1, 1, 1);
@@ -180,6 +188,18 @@ export default class ModelNode extends EditorNodeMixin(Model) {
     }
 
     return this;
+  }
+
+  onAdd() {
+    if (this.model) {
+      this.editor.renderer.addBatchedObject(this.model);
+    }
+  }
+
+  onRemove() {
+    if (this.model) {
+      this.editor.renderer.removeBatchedObject(this.model);
+    }
   }
 
   updateStaticModes() {

--- a/src/editor/renderer/Renderer.js
+++ b/src/editor/renderer/Renderer.js
@@ -192,13 +192,13 @@ export default class Renderer {
         child.setShadowsEnabled(renderMode.enableShadows);
       }
 
+      if (child.isMesh) {
+        this.batchManager.addMesh(child);
+      }
+
       if (renderMode.disableBatching && !child.layers.test(renderMode.enabledBatchedObjectLayers)) {
         child.layers.enable(0);
         child.layers.enable(2);
-      }
-
-      if (child.isMesh) {
-        this.batchManager.addMesh(child);
       }
     });
 

--- a/src/editor/renderer/Renderer.js
+++ b/src/editor/renderer/Renderer.js
@@ -92,21 +92,21 @@ class UnlitRenderMode extends RenderMode {
   }
 }
 
+class LitRenderMode extends UnlitRenderMode {
+  constructor(renderer, editor, spokeRenderer) {
+    super(renderer, editor, spokeRenderer);
+    this.name = "Lit";
+    this.enableShadows = false;
+    this.disableBatching = true;
+  }
+}
+
 class ShadowsRenderMode extends UnlitRenderMode {
   constructor(renderer, editor, spokeRenderer) {
     super(renderer, editor, spokeRenderer);
     this.name = "Shadows";
     this.disableBatching = true;
     this.enableShadows = true;
-  }
-}
-
-class NoShadowsRenderMode extends UnlitRenderMode {
-  constructor(renderer, editor, spokeRenderer) {
-    super(renderer, editor, spokeRenderer);
-    this.name = "No Shadows";
-    this.enableShadows = false;
-    this.disableBatching = true;
   }
 }
 
@@ -148,8 +148,8 @@ export default class Renderer {
     this.shadowsRenderMode = new ShadowsRenderMode(renderer, editor, this);
     this.renderModes = [
       this.renderMode,
+      new LitRenderMode(renderer, editor, this),
       this.shadowsRenderMode,
-      new NoShadowsRenderMode(renderer, editor, this),
       new WireframeRenderMode(renderer, editor, this),
       new NormalsRenderMode(renderer, editor, this)
     ];

--- a/src/editor/renderer/Renderer.js
+++ b/src/editor/renderer/Renderer.js
@@ -5,6 +5,7 @@ import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass";
 import OutlinePass from "./OutlinePass";
 import { getCanvasBlob } from "../utils/thumbnails";
 import makeRenderer from "./makeRenderer";
+import SpokeBatchRawUniformGroup from "./SpokeBatchRawUniformGroup";
 
 /**
  * @author mrdoob / http://mrdoob.com/
@@ -172,7 +173,9 @@ export default class Renderer {
   }
 
   onSceneSet = () => {
-    this.batchManager = new BatchManager(this.editor.scene, this.renderer);
+    this.batchManager = new BatchManager(this.editor.scene, this.renderer, {
+      ubo: new SpokeBatchRawUniformGroup(512)
+    });
     this.renderMode.onSceneSet();
   };
 

--- a/src/editor/renderer/Renderer.js
+++ b/src/editor/renderer/Renderer.js
@@ -23,7 +23,7 @@ class RenderMode {
 }
 
 class ShadowsRenderMode extends RenderMode {
-  constructor(renderer, editor) {
+  constructor(renderer, editor, spokeRenderer) {
     super(renderer, editor);
     this.name = "Shadows";
     this.effectComposer = new EffectComposer(renderer);
@@ -39,7 +39,8 @@ class ShadowsRenderMode extends RenderMode {
       new Vector2(canvasParent.offsetWidth, canvasParent.offsetHeight),
       editor.scene,
       editor.camera,
-      editor.selectedTransformRoots
+      editor.selectedTransformRoots,
+      spokeRenderer
     );
     this.outlinePass.edgeColor = new Color("#006EFF");
     this.outlinePass.renderToScreen = true;
@@ -110,12 +111,12 @@ export default class Renderer {
     renderer.setPixelRatio(window.devicePixelRatio);
     this.renderer = renderer;
 
-    this.renderMode = new ShadowsRenderMode(renderer, editor);
+    this.renderMode = new ShadowsRenderMode(renderer, editor, this);
     this.renderModes = [
       this.renderMode,
-      new NoShadowsRenderMode(renderer, editor),
-      new WireframeRenderMode(renderer, editor),
-      new NormalsRenderMode(renderer, editor)
+      new NoShadowsRenderMode(renderer, editor, this),
+      new WireframeRenderMode(renderer, editor, this),
+      new NormalsRenderMode(renderer, editor, this)
     ];
 
     this.screenshotRenderer = makeRenderer(1920, 1080);

--- a/src/editor/renderer/Renderer.js
+++ b/src/editor/renderer/Renderer.js
@@ -140,9 +140,6 @@ export default class Renderer {
   onSceneSet = () => {
     console.log("onSceneSet", this.editor.scene.name);
     this.batchManager = new BatchManager(this.editor.scene, this.renderer);
-    const renderer = this.renderer;
-    this.screenshotRenderer.dispose();
-    renderer.dispose();
     this.renderMode.onSceneSet();
 
     // for (const batch of this.batchManager.batches) {
@@ -243,5 +240,8 @@ export default class Renderer {
     return { blob, cameraTransform };
   };
 
-  dispose() {}
+  dispose() {
+    this.renderer.dispose();
+    this.screenshotRenderer.dispose();
+  }
 }

--- a/src/editor/renderer/Renderer.js
+++ b/src/editor/renderer/Renderer.js
@@ -138,22 +138,15 @@ export default class Renderer {
   }
 
   onSceneSet = () => {
-    console.log("onSceneSet", this.editor.scene.name);
     this.batchManager = new BatchManager(this.editor.scene, this.renderer);
     this.renderMode.onSceneSet();
-
-    // for (const batch of this.batchManager.batches) {
-    //   this.editor.scene.add(batch);
-    // }
-
-    this.batchManager.scene = this.editor.scene;
   };
 
   addBatchedObject(object) {
     if (!this.batchManager) {
       return;
     }
-    console.log("addBatchedObject", this.editor.scene.name);
+
     object.traverse(child => {
       if (child.isMesh) {
         if (this.batchManager.addMesh(child));

--- a/src/editor/renderer/Renderer.js
+++ b/src/editor/renderer/Renderer.js
@@ -145,9 +145,10 @@ export default class Renderer {
     this.renderer = renderer;
 
     this.renderMode = new UnlitRenderMode(renderer, editor, this);
+    this.shadowsRenderMode = new ShadowsRenderMode(renderer, editor, this);
     this.renderModes = [
       this.renderMode,
-      new ShadowsRenderMode(renderer, editor, this),
+      this.shadowsRenderMode,
       new NoShadowsRenderMode(renderer, editor, this),
       new WireframeRenderMode(renderer, editor, this),
       new NormalsRenderMode(renderer, editor, this)
@@ -252,7 +253,11 @@ export default class Renderer {
       }
     });
 
-    screenshotRenderer.render(this.editor.scene, camera);
+    if (this.renderMode !== this.shadowsRenderMode) {
+      this.shadowsRenderMode.onSceneSet();
+    }
+
+    this.screenshotRenderer.render(this.editor.scene, camera);
 
     camera.layers.enable(1);
 
@@ -266,6 +271,8 @@ export default class Renderer {
     this.editor.disableUpdate = false;
 
     this.renderer = originalRenderer;
+
+    this.renderMode.onSceneSet();
 
     this.editor.scene.traverse(child => {
       if (child.isNode) {

--- a/src/editor/renderer/SpokeBatchRawUniformGroup.js
+++ b/src/editor/renderer/SpokeBatchRawUniformGroup.js
@@ -35,10 +35,11 @@ export default class SpokeBatchRawUniformGroup extends BatchRawUniformGroup {
   update(_time) {
     for (let instanceId = 0; instanceId < this.meshes.length; instanceId++) {
       const mesh = this.meshes[instanceId];
+
       if (!mesh) {
         continue;
       }
-      // TODO need to account for nested visibility deeper than 1 level
+
       this.setInstanceTransform(instanceId, getVisibility(mesh) ? mesh.matrixWorld : HIDE_MATRIX);
       this.setInstanceColor(instanceId, mesh.material.color || DEFAULT_COLOR, mesh.material.opacity || 1);
 

--- a/src/editor/renderer/SpokeBatchRawUniformGroup.js
+++ b/src/editor/renderer/SpokeBatchRawUniformGroup.js
@@ -5,6 +5,20 @@ const DEFAULT_COLOR = new Color(1, 1, 1);
 const HIDE_MATRIX = new Matrix4().makeScale(0, 0, 0);
 const tempUvTransform = [0, 0, 0, 0];
 
+function getVisibility(object) {
+  let curObj = object;
+
+  while (curObj && !curObj.isNode) {
+    curObj = curObj.parent;
+  }
+
+  if (!curObj) {
+    return false;
+  }
+
+  return curObj.visible;
+}
+
 export default class SpokeBatchRawUniformGroup extends BatchRawUniformGroup {
   meshAtlases = new Map();
 
@@ -25,7 +39,7 @@ export default class SpokeBatchRawUniformGroup extends BatchRawUniformGroup {
         continue;
       }
       // TODO need to account for nested visibility deeper than 1 level
-      this.setInstanceTransform(instanceId, mesh.visible && mesh.parent.visible ? mesh.matrixWorld : HIDE_MATRIX);
+      this.setInstanceTransform(instanceId, getVisibility(mesh) ? mesh.matrixWorld : HIDE_MATRIX);
       this.setInstanceColor(instanceId, mesh.material.color || DEFAULT_COLOR, mesh.material.opacity || 1);
 
       const material = mesh.material;

--- a/src/editor/renderer/SpokeBatchRawUniformGroup.js
+++ b/src/editor/renderer/SpokeBatchRawUniformGroup.js
@@ -1,0 +1,50 @@
+import { Color, Matrix4, ClampToEdgeWrapping } from "three";
+import { BatchRawUniformGroup } from "@mozillareality/three-batch-manager";
+
+const DEFAULT_COLOR = new Color(1, 1, 1);
+const HIDE_MATRIX = new Matrix4().makeScale(0, 0, 0);
+const tempUvTransform = [0, 0, 0, 0];
+
+export default class SpokeBatchRawUniformGroup extends BatchRawUniformGroup {
+  meshAtlases = new Map();
+
+  addMesh(mesh, atlas) {
+    this.meshAtlases.set(mesh, atlas);
+    return super.addMesh(mesh, atlas);
+  }
+
+  removeMesh(mesh, atlas) {
+    this.meshAtlases.delete(mesh);
+    return super.removeMesh(mesh, atlas);
+  }
+
+  update(_time) {
+    for (let instanceId = 0; instanceId < this.meshes.length; instanceId++) {
+      const mesh = this.meshes[instanceId];
+      if (!mesh) {
+        continue;
+      }
+      // TODO need to account for nested visibility deeper than 1 level
+      this.setInstanceTransform(instanceId, mesh.visible && mesh.parent.visible ? mesh.matrixWorld : HIDE_MATRIX);
+      this.setInstanceColor(instanceId, mesh.material.color || DEFAULT_COLOR, mesh.material.opacity || 1);
+
+      const material = mesh.material;
+      const atlas = this.meshAtlases.get(mesh);
+      if (atlas) {
+        if (material.map) {
+          const textureId = atlas.addTexture(material.map, tempUvTransform);
+          if (textureId === undefined) {
+            console.warn("Mesh could not be batched. Texture atlas full.");
+            this.freeId(instanceId);
+            return false;
+          }
+          this.setInstanceUVTransform(instanceId, tempUvTransform);
+          this.setInstanceMapSettings(instanceId, textureId[0], material.map.wrapS, material.map.wrapT);
+        } else {
+          this.setInstanceUVTransform(instanceId, atlas.nullTextureTransform);
+          this.setInstanceMapSettings(instanceId, atlas.nullTextureIndex[0], ClampToEdgeWrapping, ClampToEdgeWrapping);
+        }
+      }
+    }
+  }
+}

--- a/src/ui/EditorContainer.js
+++ b/src/ui/EditorContainer.js
@@ -234,6 +234,7 @@ export default class EditorContainer extends Component {
     editor.removeListener("saveProject", this.onSaveProject);
     editor.removeListener("initialized", this.onEditorInitialized);
     editor.removeListener("error", this.onEditorError);
+    editor.dispose();
   }
 
   onResize = () => {

--- a/src/ui/Error.js
+++ b/src/ui/Error.js
@@ -21,7 +21,7 @@ const StyledError = styled.div`
 
 export default class Error extends Component {
   static propTypes = {
-    message: PropTypes.string
+    message: PropTypes.node
   };
 
   render() {

--- a/src/ui/projects/ProjectPage.js
+++ b/src/ui/projects/ProjectPage.js
@@ -27,6 +27,40 @@ class ProjectPage extends Component {
     const projectId = match.params.projectId;
     const queryParams = new URLSearchParams(location.search);
 
+    // Check for WebGL2 support
+    if (!window.WebGL2RenderingContext) {
+      this.setState({
+        error: (
+          <p>
+            Your browser does not support WebGL2. Please visit{" "}
+            <a href="http://get.webgl.org/webgl2/">http://get.webgl.org/webgl2/</a> for more info.
+          </p>
+        )
+      });
+    }
+
+    const canvas = document.createElement("canvas");
+
+    let gl;
+
+    try {
+      gl = canvas.getContext("webgl2");
+    } catch (err) {
+      gl = null;
+    }
+
+    if (!gl) {
+      this.setState({
+        error: (
+          <p>
+            Error, could not initialize WebGL2. Please visit{" "}
+            <a href="http://get.webgl.org/webgl2/troubleshooting">http://get.webgl.org/webgl2/troubleshooting</a> for
+            more info.
+          </p>
+        )
+      });
+    }
+
     if (projectId === "new") {
       if (queryParams.has("template")) {
         this.loadProjectTemplate(queryParams.get("template"));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1217,6 +1217,11 @@
   resolved "https://registry.yarnpkg.com/@mozillareality/easing-functions/-/easing-functions-0.1.1.tgz#de7994336412b02e7d58e8391d0c230df8b79ad2"
   integrity sha512-rApZ0OOqreMULwHZOy+fB9wRLnikelE8pMbqUmtLBhT6OSKp5dz/7pA/EjnFXJDQBR/EgZUa3vwbFlTZnUgSlw==
 
+"@mozillareality/three-batch-manager@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@mozillareality/three-batch-manager/-/three-batch-manager-0.1.4.tgz#301d19c160043d0cc7cfea3efba89cf630cc8dde"
+  integrity sha512-cPcgCF2DG6SL4E0gjIQOsJ7SxcMGbGNWjKS9pXxhLp6GTV63nEUZ0geWBnImEG48BQvyXT6Kbjw2xBiGPxE3tA==
+
 "@mozillareality/three-particle-emitter@^0.1.5":
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@mozillareality/three-particle-emitter/-/three-particle-emitter-0.1.5.tgz#6ddd864b5f011f745bb7c5c406853a1fc8684fe6"


### PR DESCRIPTION
Spoke now achieves similar performance to Hubs when working with complex scenes. You can now work with hundreds of nodes in your scene without your editor slowing to a crawl.

Spoke now defaults to Unlit mode which uses batching under the hood. If you want to preview the scene as it would look in Hubs, you can switch the render mode to "Shadows" in the dropdown at top right corner of the viewport.

Also, Spoke now requires WebGL2 support. This hopefully shouldn't be a problem as most desktop browsers now support WebGL2.