### PR TITLE
Properly handle modification state

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -205,8 +205,13 @@ export default class Editor extends EventEmitter {
 
     this.initialized = true;
 
-    this.addListener("objectsChanged", () => (this.sceneModified = true));
+    this.addListener("objectsChanged", this.onObjectsChanged);
     this.emit("initialized");
+  }
+
+  onObjectsChanged() {
+    this.sceneModified = true;
+    this.emit("sceneModified");
   }
 
   initializeRenderer(canvas) {

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -205,6 +205,7 @@ export default class Editor extends EventEmitter {
 
     this.initialized = true;
 
+    this.addListener("objectsChanged", () => (this.sceneModified = true));
     this.emit("initialized");
   }
 

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -205,11 +205,12 @@ export default class Editor extends EventEmitter {
 
     this.initialized = true;
 
-    this.addListener("objectsChanged", this.onObjectsChanged);
+    this.addListener("objectsChanged", this.onEmitSceneModified);
+    this.addListener("sceneGraphChanged", this.onEmitSceneModified);
     this.emit("initialized");
   }
 
-  onObjectsChanged() {
+  onEmitSceneModified() {
     this.sceneModified = true;
     this.emit("sceneModified");
   }

--- a/src/ui/EditorContainer.js
+++ b/src/ui/EditorContainer.js
@@ -83,8 +83,8 @@ export default class EditorContainer extends Component {
     };
   }
 
-  updateModifiedState = () => {
-    this.setState({ modified: this.state.editor.sceneModified && !this.state.creatingProject });
+  updateModifiedState = then => {
+    this.setState({ modified: this.state.editor.sceneModified && !this.state.creatingProject }, then);
   };
 
   generateToolbarMenu = () => {
@@ -222,7 +222,6 @@ export default class EditorContainer extends Component {
     this.loadProject(this.props.project).catch(console.error);
     window.addEventListener("resize", this.onResize);
     this.onResize();
-    editor.addListener("objectsChanged", this.onObjectsChanged);
     editor.addListener("projectLoaded", this.onProjectLoaded);
     editor.addListener("sceneModified", this.onSceneModified);
     editor.addListener("saveProject", this.onSaveProject);
@@ -241,14 +240,11 @@ export default class EditorContainer extends Component {
   componentWillUnmount() {
     window.removeEventListener("resize", this.onResize);
 
-    this.props.project.removeListener("project-saved", this.onProjectSaved);
-
     const editor = this.state.editor;
     editor.removeListener("sceneModified", this.onSceneModified);
     editor.removeListener("saveProject", this.onSaveProject);
     editor.removeListener("initialized", this.onEditorInitialized);
     editor.removeListener("error", this.onEditorError);
-    editor.removeListener("objectsChanged", this.onObjectsChanged);
     editor.removeListener("projectLoaded", this.onProjectLoaded);
     editor.dispose();
   }
@@ -300,14 +296,10 @@ export default class EditorContainer extends Component {
   };
 
   onSceneModified = () => {
-    this.setState({ toolbarMenu: this.generateToolbarMenu() });
-  };
-
-  onProjectLoaded = () => {
     this.updateModifiedState();
   };
 
-  onObjectsChanged = () => {
+  onProjectLoaded = () => {
     this.updateModifiedState();
   };
 
@@ -411,10 +403,13 @@ export default class EditorContainer extends Component {
         this.showDialog,
         this.hideDialog
       );
+      editor.sceneModified = false;
       editor.projectId = projectId;
-      this.setState({ creatingProject: true }, () => {
-        this.props.history.replace(`/projects/${projectId}`);
-        this.setState({ creatingProject: false });
+      this.updateModifiedState(() => {
+        this.setState({ creatingProject: true }, () => {
+          this.props.history.replace(`/projects/${projectId}`);
+          this.setState({ creatingProject: false });
+        });
       });
     }
   }

--- a/src/ui/router/BrowserPrompt.js
+++ b/src/ui/router/BrowserPrompt.js
@@ -4,7 +4,6 @@ import PropTypes from "prop-types";
 
 export default class BrowserPrompt extends React.Component {
   static propTypes = {
-    when: PropTypes.bool,
     message: PropTypes.oneOfType([PropTypes.func, PropTypes.string]).isRequired
   };
 


### PR DESCRIPTION
This fixes some UX issues with scene modification state, one of which is arguably a P0 issue. Most of this behavior has regressed since we no longer were setting the `sceneModified` flag to true nor firing the `sceneModified` event. 

- The `onSceneModified` event now properly fires, which wasn't working before.

- We now properly save the project on publish if it is modified. Prior to this PR, if you edited a scene, published it, and reloaded, your changes would have been lost unless you hit Save.

- The modification state is now reflected in the title of the page

- We no longer nag you about leaving the page if you have not modified the scene

Also, I wasn't sure if there was some reason this behavior was specifically altered to be more conservative (wrt warning the user) -- this PR assumed that `objectsChanged` is a sufficient event to subscribe to to know if there has been a scene modification. lmk if that isn't right.
