### PR TITLE
Multiple Object Editing

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -78,6 +78,7 @@ import TranslateMultipleCommand from "./commands/TranslateMultipleCommand";
 import GroupMultipleCommand from "./commands/GroupMultipleCommand";
 import ReparentMultipleWithPositionCommand from "./commands/ReparentMultipleWithPositionCommand";
 import LoadMaterialSlotCommand from "./commands/LoadMaterialSlotCommand";
+import LoadMaterialSlotMultipleCommand from "./commands/LoadMaterialSlotMultipleCommand";
 
 import GroupNode from "./nodes/GroupNode";
 import ModelNode from "./nodes/ModelNode";
@@ -1728,7 +1729,7 @@ export default class Editor extends EventEmitter {
   }
 
   setPropertiesSelected(properties, useHistory = true, emitEvent = true) {
-    return this.setPropertyMultiple(this.selected, properties, useHistory, emitEvent);
+    return this.setPropertiesMultiple(this.selected, properties, useHistory, emitEvent);
   }
 
   loadMaterialSlot(object, subPieceId, materialSlotId, materialId, useHistory = true, emitEvent = true) {
@@ -1747,6 +1748,32 @@ export default class Editor extends EventEmitter {
     }
 
     return object;
+  }
+
+  loadMaterialSlotMultiple(objects, subPieceId, materialSlotId, materialId, useHistory = true, emitEvent = true) {
+    if (useHistory) {
+      return this.history.execute(
+        new LoadMaterialSlotMultipleCommand(this, objects, subPieceId, materialSlotId, materialId)
+      );
+    }
+
+    for (const object of objects) {
+      object.loadMaterialSlot(subPieceId, materialSlotId, materialId).catch(console.error);
+
+      if (object.onChange) {
+        object.onChange("materialSlot");
+      }
+    }
+
+    if (emitEvent) {
+      this.emit("objectsChanged", objects, "materialSlot");
+    }
+
+    return objects;
+  }
+
+  loadMaterialSlotSelected(subPieceId, materialSlotId, materialId, useHistory = true, emitEvent = true) {
+    return this.loadMaterialSlotMultiple(this.selected, subPieceId, materialSlotId, materialId, useHistory, emitEvent);
   }
 
   getRootObjects(objects, target = [], filterUnremovable = true, filterUntransformable = false) {

--- a/src/editor/commands/LoadMaterialSlotMultipleCommand.js
+++ b/src/editor/commands/LoadMaterialSlotMultipleCommand.js
@@ -1,0 +1,32 @@
+import Command from "./Command";
+import { serializeObject3DArray } from "../utils/debug";
+
+export default class LoadMaterialSlotMultipleCommand extends Command {
+  constructor(editor, objects, subPieceId, materialSlotId, materialId) {
+    super(editor);
+    this.objects = objects.slice(0);
+    this.subPieceId = subPieceId;
+    this.materialSlotId = materialSlotId;
+    this.materialId = materialId;
+    this.prevMaterialIds = objects.map(object => object.getMaterialIdForMaterialSlot(subPieceId, materialSlotId));
+  }
+
+  execute() {
+    this.editor.loadMaterialSlotMultiple(this.objects, this.subPieceId, this.materialSlotId, this.materialId, false);
+  }
+
+  undo() {
+    for (let i = 0; i < this.objects.length; i++) {
+      const object = this.objects[i];
+      this.editor.loadMaterialSlot(object, this.subPieceId, this.materialSlotId, this.prevMaterialIds[i], false, false);
+    }
+
+    this.emit("objectsChanged", this.objects, "materialSlot");
+  }
+
+  toString() {
+    return `LoadMaterialSlotMultipleCommand id: ${this.id} objects: ${serializeObject3DArray(
+      this.objects
+    )} subPieceId: ${this.subPieceId} materialSlotId: ${this.materialSlotId} materialId: ${this.materialId}`;
+  }
+}

--- a/src/editor/commands/SetPropertyMultipleCommand.js
+++ b/src/editor/commands/SetPropertyMultipleCommand.js
@@ -38,7 +38,7 @@ export default class SetPropertyMultipleCommand extends Command {
       this.newValue = newValue;
     }
 
-    this.editor.setPropertyMultiple(this.object, this.propertyName, this.newValue, false);
+    this.editor.setPropertyMultiple(this.objects, this.propertyName, this.newValue, false);
   }
 
   undo() {

--- a/src/editor/nodes/EditorNodeMixin.js
+++ b/src/editor/nodes/EditorNodeMixin.js
@@ -23,6 +23,8 @@ export default function EditorNodeMixin(Object3DClass) {
     // Used for props like src that have side effects that we don't want to happen in the constructor
     static initialElementProps = {};
 
+    static hideInElementsPanel = false;
+
     static canAddNode(_editor) {
       return true;
     }

--- a/src/editor/nodes/KitPieceNode.js
+++ b/src/editor/nodes/KitPieceNode.js
@@ -10,6 +10,8 @@ export default class KitPieceNode extends EditorNodeMixin(Model) {
 
   static experimental = true;
 
+  static hideInElementsPanel = true;
+
   static useMultiplePlacementMode = true;
 
   static nodeName = "Kit Piece";
@@ -89,15 +91,31 @@ export default class KitPieceNode extends EditorNodeMixin(Model) {
 
   getMaterialIdForMaterialSlot(subPieceId, materialSlotId) {
     const subPiece = this.subPieces.find(s => s.id === subPieceId);
-    const materialSlot = subPiece.materialSlots.find(m => m.id === materialSlotId);
-    return materialSlot.value ? materialSlot.value.id : undefined;
+    const materialSlot = subPiece && subPiece.materialSlots.find(m => m.id === materialSlotId);
+    return materialSlot && materialSlot.value ? materialSlot.value.id : undefined;
   }
 
   async loadMaterialSlot(subPieceId, materialSlotId, materialId) {
-    const loader = this.editor.gltfCache.getLoader(this._src);
-    const _materialId = this.materialIds.find(m => m.id === materialId);
     const subPiece = this.subPieces.find(s => s.id === subPieceId);
+
+    if (!subPiece) {
+      return;
+    }
+
     const materialSlot = subPiece.materialSlots.find(m => m.id === materialSlotId);
+
+    if (!materialSlot) {
+      return;
+    }
+
+    const _materialId = this.materialIds.find(m => m.id === materialId);
+
+    if (!_materialId) {
+      return;
+    }
+
+    const loader = this.editor.gltfCache.getLoader(this._src);
+
     materialSlot.value = _materialId;
 
     const material = await loader.getDependency("material", _materialId.index);

--- a/src/ui/assets/sources/ElementsSource.js
+++ b/src/ui/assets/sources/ElementsSource.js
@@ -33,7 +33,7 @@ export default class ElementsSource extends BaseSource {
         return acc;
       }
 
-      if (nodeType.experimental && !this.enableExperimentalFeatures) {
+      if ((nodeType.experimental && !this.enableExperimentalFeatures) || nodeType.hideInElementsPanel) {
         return acc;
       }
 

--- a/src/ui/properties/AmbientLightNodeEditor.js
+++ b/src/ui/properties/AmbientLightNodeEditor.js
@@ -17,11 +17,11 @@ export default class AmbientLightNodeEditor extends Component {
   static description = "A light which illuminates all objects in your scene.";
 
   onChangeColor = color => {
-    this.props.editor.setProperty(this.props.node, "color", color);
+    this.props.editor.setPropertySelected("color", color);
   };
 
   onChangeIntensity = intensity => {
-    this.props.editor.setProperty(this.props.node, "intensity", intensity);
+    this.props.editor.setPropertySelected("intensity", intensity);
   };
 
   render() {

--- a/src/ui/properties/BoxColliderNodeEditor.js
+++ b/src/ui/properties/BoxColliderNodeEditor.js
@@ -17,7 +17,7 @@ export default class BoxColliderNodeEditor extends Component {
     "An invisible box that objects will bounce off of or rest on top of.\nWithout colliders, objects will fall through floors and go through walls.";
 
   onChangeWalkable = walkable => {
-    this.props.editor.setProperty(this.props.node, "walkable", walkable);
+    this.props.editor.setPropertySelected("walkable", walkable);
   };
 
   render() {

--- a/src/ui/properties/DirectionalLightNodeEditor.js
+++ b/src/ui/properties/DirectionalLightNodeEditor.js
@@ -18,11 +18,11 @@ export default class DirectionalLightNodeEditor extends Component {
   static description = "A light which illuminates the entire scene, but emits along a single direction.";
 
   onChangeColor = color => {
-    this.props.editor.setProperty(this.props.node, "color", color);
+    this.props.editor.setPropertySelected("color", color);
   };
 
   onChangeIntensity = intensity => {
-    this.props.editor.setProperty(this.props.node, "intensity", intensity);
+    this.props.editor.setPropertySelected("intensity", intensity);
   };
 
   render() {

--- a/src/ui/properties/FloorPlanNodeEditor.js
+++ b/src/ui/properties/FloorPlanNodeEditor.js
@@ -33,7 +33,7 @@ class FloorPlanNodeEditor extends Component {
 
   constructor(props) {
     super(props);
-    const createPropSetter = propName => value => this.props.editor.setProperty(this.props.node, propName, value);
+    const createPropSetter = propName => value => this.props.editor.setPropertySelected(propName, value);
     this.onChangeAutoCellSize = createPropSetter("autoCellSize");
     this.onChangeCellSize = createPropSetter("cellSize");
     this.onChangeCellHeight = createPropSetter("cellHeight");

--- a/src/ui/properties/GroundPlaneNodeEditor.js
+++ b/src/ui/properties/GroundPlaneNodeEditor.js
@@ -17,15 +17,15 @@ export default class GroundPlaneNodeEditor extends Component {
   static description = "A flat ground plane that extends into the distance.";
 
   onChangeColor = color => {
-    this.props.editor.setProperty(this.props.node, "color", color);
+    this.props.editor.setPropertySelected("color", color);
   };
 
   onChangeReceiveShadow = receiveShadow => {
-    this.props.editor.setProperty(this.props.node, "receiveShadow", receiveShadow);
+    this.props.editor.setPropertySelected("receiveShadow", receiveShadow);
   };
 
   onChangeWalkable = walkable => {
-    this.props.editor.setProperty(this.props.node, "walkable", walkable);
+    this.props.editor.setPropertySelected("walkable", walkable);
   };
 
   render() {

--- a/src/ui/properties/HemisphereLightNodeEditor.js
+++ b/src/ui/properties/HemisphereLightNodeEditor.js
@@ -17,15 +17,15 @@ export default class HemisphereLightNodeEditor extends Component {
   static description = "A light which illuminates the scene from directly overhead.";
 
   onChangeSkyColor = skyColor => {
-    this.props.editor.setProperty(this.props.node, "skyColor", skyColor);
+    this.props.editor.setPropertySelected("skyColor", skyColor);
   };
 
   onChangeGroundColor = groundColor => {
-    this.props.editor.setProperty(this.props.node, "groundColor", groundColor);
+    this.props.editor.setPropertySelected("groundColor", groundColor);
   };
 
   onChangeIntensity = intensity => {
-    this.props.editor.setProperty(this.props.node, "intensity", intensity);
+    this.props.editor.setPropertySelected("intensity", intensity);
   };
 
   render() {

--- a/src/ui/properties/ImageNodeEditor.js
+++ b/src/ui/properties/ImageNodeEditor.js
@@ -20,11 +20,11 @@ export default class ImageNodeEditor extends Component {
   static description = "Dynamically loads an image.";
 
   onChangeSrc = src => {
-    this.props.editor.setProperty(this.props.node, "src", src);
+    this.props.editor.setPropertySelected("src", src);
   };
 
   onChangeProjection = value => {
-    this.props.editor.setProperty(this.props.node, "projection", value);
+    this.props.editor.setPropertySelected("projection", value);
   };
 
   render() {

--- a/src/ui/properties/LightShadowProperties.js
+++ b/src/ui/properties/LightShadowProperties.js
@@ -36,19 +36,19 @@ export default class LightShadowProperties extends Component {
   };
 
   onChangeShadowMapResolution = shadowMapResolution => {
-    this.props.editor.setProperty(this.props.node, "shadowMapResolution", shadowMapResolution);
+    this.props.editor.setPropertySelected("shadowMapResolution", shadowMapResolution);
   };
 
   onChangeCastShadow = castShadow => {
-    this.props.editor.setProperty(this.props.node, "castShadow", castShadow);
+    this.props.editor.setPropertySelected("castShadow", castShadow);
   };
 
   onChangeShadowBias = shadowBias => {
-    this.props.editor.setProperty(this.props.node, "shadowBias", shadowBias);
+    this.props.editor.setPropertySelected("shadowBias", shadowBias);
   };
 
   onChangeShadowRadius = shadowRadius => {
-    this.props.editor.setProperty(this.props.node, "shadowRadius", shadowRadius);
+    this.props.editor.setPropertySelected("shadowRadius", shadowRadius);
   };
 
   render() {

--- a/src/ui/properties/LinkNodeEditor.js
+++ b/src/ui/properties/LinkNodeEditor.js
@@ -16,7 +16,7 @@ export default class LinkNodeEditor extends Component {
   static description = "Link to a Hubs room.";
 
   onChangeHref = href => {
-    this.props.editor.setProperty(this.props.node, "href", href);
+    this.props.editor.setPropertySelected("href", href);
   };
 
   render() {

--- a/src/ui/properties/ModelNodeEditor.js
+++ b/src/ui/properties/ModelNodeEditor.js
@@ -10,7 +10,8 @@ import { Cube } from "styled-icons/fa-solid/Cube";
 export default class ModelNodeEditor extends Component {
   static propTypes = {
     editor: PropTypes.object,
-    node: PropTypes.object
+    node: PropTypes.object,
+    multiEdit: PropTypes.bool
   };
 
   static iconComponent = Cube;
@@ -18,32 +19,39 @@ export default class ModelNodeEditor extends Component {
   static description = "A 3D model in your scene, loaded from a GLTF URL or file.";
 
   onChangeSrc = (src, { scaleToFit }) => {
-    if (scaleToFit) {
-      this.props.node.scaleToFit = scaleToFit;
-    }
-
-    this.props.editor.setProperty(this.props.node, "src", src);
+    console.log(src, scaleToFit);
+    this.props.editor.setPropertiesSelected({ scaleToFit: scaleToFit || false, src });
   };
 
   onChangeAnimation = activeClipIndex => {
-    this.props.editor.setProperty(this.props.node, "activeClipIndex", activeClipIndex);
+    this.props.editor.setPropertySelected("activeClipIndex", activeClipIndex);
   };
 
   onChangeCollidable = collidable => {
-    this.props.editor.setProperty(this.props.node, "collidable", collidable);
+    this.props.editor.setPropertySelected("collidable", collidable);
   };
 
   onChangeWalkable = walkable => {
-    this.props.editor.setProperty(this.props.node, "walkable", walkable);
+    this.props.editor.setPropertySelected("walkable", walkable);
   };
 
   onChangeCastShadow = castShadow => {
-    this.props.editor.setProperty(this.props.node, "castShadow", castShadow);
+    this.props.editor.setPropertySelected("castShadow", castShadow);
   };
 
   onChangeReceiveShadow = receiveShadow => {
-    this.props.editor.setProperty(this.props.node, "receiveShadow", receiveShadow);
+    this.props.editor.setPropertySelected("receiveShadow", receiveShadow);
   };
+
+  isAnimationPropertyDisabled() {
+    const { multiEdit, editor, node } = this.props;
+
+    if (multiEdit) {
+      return editor.selected.some(selectedNode => selectedNode.src !== node.src);
+    }
+
+    return false;
+  }
 
   render() {
     const node = this.props.node;
@@ -54,7 +62,12 @@ export default class ModelNodeEditor extends Component {
           <ModelInput value={node.src} onChange={this.onChangeSrc} />
         </InputGroup>
         <InputGroup name="Loop Animation">
-          <SelectInput options={node.getClipOptions()} value={node.activeClipIndex} onChange={this.onChangeAnimation} />
+          <SelectInput
+            disabled={this.isAnimationPropertyDisabled()}
+            options={node.getClipOptions()}
+            value={node.activeClipIndex}
+            onChange={this.onChangeAnimation}
+          />
         </InputGroup>
         <InputGroup name="Collidable">
           <BooleanInput value={node.collidable} onChange={this.onChangeCollidable} />

--- a/src/ui/properties/NameInputGroup.js
+++ b/src/ui/properties/NameInputGroup.js
@@ -41,7 +41,7 @@ export default class NameInputGroup extends Component {
     // Check that the focused node is current node before setting the property.
     // This can happen when clicking on another node in the HierarchyPanel
     if (this.props.node.name !== this.state.name && this.props.node === this.state.focusedNode) {
-      this.props.editor.setProperty(this.props.node, "name", this.state.name);
+      this.props.editor.setPropertySelected("name", this.state.name);
     }
 
     this.setState({ focusedNode: null });
@@ -50,7 +50,7 @@ export default class NameInputGroup extends Component {
   onKeyUpName = e => {
     if (e.key === "Enter") {
       e.preventDefault();
-      this.props.editor.setProperty(this.props.node, "name", this.state.name);
+      this.props.editor.setPropertySelected("name", this.state.name);
     }
   };
 

--- a/src/ui/properties/NodeEditor.js
+++ b/src/ui/properties/NodeEditor.js
@@ -1,48 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import ReactTooltip from "react-tooltip";
 import PropertyGroup from "./PropertyGroup";
-import TransformPropertyGroup from "./TransformPropertyGroup";
-import NameInputGroup from "./NameInputGroup";
-import InputGroup from "../inputs/InputGroup";
-import BooleanInput from "../inputs/BooleanInput";
-import styled from "styled-components";
-
-const StyledNodeEditor = styled.div`
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-`;
-
-const PropertiesHeader = styled.div`
-  background-color: ${props => props.theme.panel2};
-  border: none !important;
-  padding-bottom: 0 !important;
-`;
-
-const NameInputGroupContainer = styled.div`
-  display: flex;
-  flex-flow: row wrap;
-  align-items: flex-start;
-  padding: 8px 0;
-`;
-
-const VisibleInputGroup = styled(InputGroup)`
-  display: flex;
-  flex: 0;
-
-  & > label {
-    width: auto !important;
-    padding-right: 8px;
-  }
-`;
-
-const NodeEditorTooltip = styled(ReactTooltip)`
-  max-width: 200px;
-  overflow: hidden;
-  overflow-wrap: break-word;
-  user-select: none;
-`;
 
 export default class NodeEditor extends Component {
   static propTypes = {
@@ -58,31 +16,13 @@ export default class NodeEditor extends Component {
     disableTransform: false
   };
 
-  onChangeVisible = value => {
-    this.props.editor.setProperty(this.props.node, "visible", value);
-  };
-
   render() {
-    const { node, description, editor, children } = this.props;
+    const { node, description, children } = this.props;
 
     return (
-      <StyledNodeEditor>
-        <PropertiesHeader>
-          <NameInputGroupContainer>
-            <NameInputGroup node={node} editor={editor} />
-            {node.nodeName !== "Scene" && (
-              <VisibleInputGroup name="Visible">
-                <BooleanInput value={node.visible} onChange={this.onChangeVisible} />
-              </VisibleInputGroup>
-            )}
-          </NameInputGroupContainer>
-          {!node.disableTransform && <TransformPropertyGroup node={node} editor={editor} />}
-        </PropertiesHeader>
-        <PropertyGroup name={node.nodeName} description={description}>
-          {children}
-        </PropertyGroup>
-        <NodeEditorTooltip id="node-editor" />
-      </StyledNodeEditor>
+      <PropertyGroup name={node.nodeName} description={description}>
+        {children}
+      </PropertyGroup>
     );
   }
 }

--- a/src/ui/properties/ParticleEmitterNodeEditor.js
+++ b/src/ui/properties/ParticleEmitterNodeEditor.js
@@ -27,91 +27,97 @@ export default class ParticleEmitterNodeEditor extends Component {
 
   static description = "Particle emitter to create particles.";
 
+  updateParticles() {
+    for (const node of this.props.editor.selected) {
+      node.updateParticles();
+    }
+  }
+
   onChangeColorCurve = colorCurve => {
-    this.props.editor.setProperty(this.props.node, "colorCurve", colorCurve);
+    this.props.editor.setPropertySelected("colorCurve", colorCurve);
   };
 
   onChangeVelocityCurve = velocityCurve => {
-    this.props.editor.setProperty(this.props.node, "velocityCurve", velocityCurve);
+    this.props.editor.setPropertySelected("velocityCurve", velocityCurve);
   };
 
   onChangeStartColor = startColor => {
-    this.props.editor.setProperty(this.props.node, "startColor", startColor);
-    this.props.node.updateParticles();
+    this.props.editor.setPropertySelected("startColor", startColor);
+    this.updateParticles();
   };
 
   onChangeMiddleColor = middleColor => {
-    this.props.editor.setProperty(this.props.node, "middleColor", middleColor);
+    this.props.editor.setPropertySelected("middleColor", middleColor);
   };
 
   onChangeEndColor = endColor => {
-    this.props.editor.setProperty(this.props.node, "endColor", endColor);
+    this.props.editor.setPropertySelected("endColor", endColor);
   };
 
   onChangeStartOpacity = startOpacity => {
-    this.props.editor.setProperty(this.props.node, "startOpacity", startOpacity);
+    this.props.editor.setPropertySelected("startOpacity", startOpacity);
   };
 
   onChangeMiddleOpacity = middleOpacity => {
-    this.props.editor.setProperty(this.props.node, "middleOpacity", middleOpacity);
+    this.props.editor.setPropertySelected("middleOpacity", middleOpacity);
   };
 
   onChangeEndOpacity = endOpacity => {
-    this.props.editor.setProperty(this.props.node, "endOpacity", endOpacity);
+    this.props.editor.setPropertySelected("endOpacity", endOpacity);
   };
 
   onChangeSrc = src => {
-    this.props.editor.setProperty(this.props.node, "src", src);
+    this.props.editor.setPropertySelected("src", src);
   };
 
   onChangeSizeCurve = sizeCurve => {
-    this.props.editor.setProperty(this.props.node, "sizeCurve", sizeCurve);
+    this.props.editor.setPropertySelected("sizeCurve", sizeCurve);
   };
 
   onChangeStartSize = startSize => {
-    this.props.editor.setProperty(this.props.node, "startSize", startSize);
-    this.props.node.updateParticles();
+    this.props.editor.setPropertySelected("startSize", startSize);
+    this.updateParticles();
   };
 
   onChangeEndSize = endSize => {
-    this.props.editor.setProperty(this.props.node, "endSize", endSize);
+    this.props.editor.setPropertySelected("endSize", endSize);
   };
 
   onChangeSizeRandomness = sizeRandomness => {
-    this.props.editor.setProperty(this.props.node, "sizeRandomness", sizeRandomness);
-    this.props.node.updateParticles();
+    this.props.editor.setPropertySelected("sizeRandomness", sizeRandomness);
+    this.updateParticles();
   };
 
   onChangeStartVelocity = startVelocity => {
-    this.props.editor.setProperty(this.props.node, "startVelocity", startVelocity);
+    this.props.editor.setPropertySelected("startVelocity", startVelocity);
   };
 
   onChangeEndVelocity = endVelocity => {
-    this.props.editor.setProperty(this.props.node, "endVelocity", endVelocity);
+    this.props.editor.setPropertySelected("endVelocity", endVelocity);
   };
 
   onChangeAngularVelocity = angularVelocity => {
-    this.props.editor.setProperty(this.props.node, "angularVelocity", angularVelocity);
+    this.props.editor.setPropertySelected("angularVelocity", angularVelocity);
   };
 
   onChangeParticleCount = particleCount => {
-    this.props.editor.setProperty(this.props.node, "particleCount", particleCount);
-    this.props.node.updateParticles();
+    this.props.editor.setPropertySelected("particleCount", particleCount);
+    this.updateParticles();
   };
 
   onChangeLifetime = lifetime => {
-    this.props.editor.setProperty(this.props.node, "lifetime", lifetime);
-    this.props.node.updateParticles();
+    this.props.editor.setPropertySelected("lifetime", lifetime);
+    this.updateParticles();
   };
 
   onChangeAgeRandomness = ageRandomness => {
-    this.props.editor.setProperty(this.props.node, "ageRandomness", ageRandomness);
-    this.props.node.updateParticles();
+    this.props.editor.setPropertySelected("ageRandomness", ageRandomness);
+    this.updateParticles();
   };
 
   onChangeLifetimeRandomness = lifetimeRandomness => {
-    this.props.editor.setProperty(this.props.node, "lifetimeRandomness", lifetimeRandomness);
-    this.props.node.updateParticles();
+    this.props.editor.setPropertySelected("lifetimeRandomness", lifetimeRandomness);
+    this.updateParticles();
   };
 
   render() {

--- a/src/ui/properties/PointLightNodeEditor.js
+++ b/src/ui/properties/PointLightNodeEditor.js
@@ -18,15 +18,15 @@ export default class PointLightNodeEditor extends Component {
   static description = "A light which emits in all directions from a single point.";
 
   onChangeColor = color => {
-    this.props.editor.setProperty(this.props.node, "color", color);
+    this.props.editor.setPropertySelected("color", color);
   };
 
   onChangeIntensity = intensity => {
-    this.props.editor.setProperty(this.props.node, "intensity", intensity);
+    this.props.editor.setPropertySelected("intensity", intensity);
   };
 
   onChangeRange = range => {
-    this.props.editor.setProperty(this.props.node, "range", range);
+    this.props.editor.setPropertySelected("range", range);
   };
 
   render() {

--- a/src/ui/properties/PropertiesPanelContainer.js
+++ b/src/ui/properties/PropertiesPanelContainer.js
@@ -5,6 +5,47 @@ import DefaultNodeEditor from "./DefaultNodeEditor";
 import Panel from "../layout/Panel";
 import styled from "styled-components";
 import { SlidersH } from "styled-icons/fa-solid/SlidersH";
+import ReactTooltip from "react-tooltip";
+import TransformPropertyGroup from "./TransformPropertyGroup";
+import NameInputGroup from "./NameInputGroup";
+import InputGroup from "../inputs/InputGroup";
+import BooleanInput from "../inputs/BooleanInput";
+
+const StyledNodeEditor = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+`;
+
+const PropertiesHeader = styled.div`
+  background-color: ${props => props.theme.panel2};
+  border: none !important;
+  padding-bottom: 0 !important;
+`;
+
+const NameInputGroupContainer = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+  align-items: flex-start;
+  padding: 8px 0;
+`;
+
+const VisibleInputGroup = styled(InputGroup)`
+  display: flex;
+  flex: 0;
+
+  & > label {
+    width: auto !important;
+    padding-right: 8px;
+  }
+`;
+
+const NodeEditorTooltip = styled(ReactTooltip)`
+  max-width: 200px;
+  overflow: hidden;
+  overflow-wrap: break-word;
+  user-select: none;
+`;
 
 const PropertiesPanelContent = styled.div`
   display: flex;
@@ -64,6 +105,10 @@ class PropertiesPanelContainer extends Component {
     }
   };
 
+  onChangeVisible = value => {
+    this.props.editor.setPropertySelected("visible", value);
+  };
+
   render() {
     const editor = this.props.editor;
     const selected = this.state.selected;
@@ -72,24 +117,47 @@ class PropertiesPanelContainer extends Component {
 
     if (selected.length === 0) {
       content = <NoNodeSelectedMessage>No node selected</NoNodeSelectedMessage>;
-    } else if (selected.length > 1) {
-      //TODO
-      content = <NoNodeSelectedMessage>Multiple Nodes Selected</NoNodeSelectedMessage>;
     } else {
-      // TODO
-      // let NodeEditor = editor.getNodeEditor(selected[0]);
+      const activeNode = selected[selected.length - 1];
+      const NodeEditor = editor.getNodeEditor(activeNode) || DefaultNodeEditor;
 
-      // const differentNodeTypes = selected.some(selectedNode => editor.getNodeEditor(selectedNode) !== NodeEditor);
+      const multiEdit = selected.length > 1;
 
-      // if (differentNodeTypes) {
-      //   NodeEditor = DefaultNodeEditor;
-      // }
+      let showNodeEditor = true;
 
-      const node = selected[0];
+      for (let i = 0; i < selected.length - 1; i++) {
+        if (editor.getNodeEditor(selected[i]) !== NodeEditor) {
+          showNodeEditor = false;
+          break;
+        }
+      }
 
-      const NodeEditor = editor.getNodeEditor(node) || DefaultNodeEditor;
+      let nodeEditor;
 
-      content = <NodeEditor node={node} editor={editor} />;
+      if (showNodeEditor) {
+        nodeEditor = <NodeEditor multiEdit={multiEdit} node={activeNode} editor={editor} />;
+      } else {
+        nodeEditor = <NoNodeSelectedMessage>Multiple Nodes of different types selected</NoNodeSelectedMessage>;
+      }
+
+      const disableTransform = selected.some(node => node.disableTransform);
+
+      content = (
+        <StyledNodeEditor>
+          <PropertiesHeader>
+            <NameInputGroupContainer>
+              <NameInputGroup node={activeNode} editor={editor} />
+              {activeNode.nodeName !== "Scene" && (
+                <VisibleInputGroup name="Visible">
+                  <BooleanInput value={activeNode.visible} onChange={this.onChangeVisible} />
+                </VisibleInputGroup>
+              )}
+            </NameInputGroupContainer>
+            {!disableTransform && <TransformPropertyGroup node={activeNode} editor={editor} />}
+          </PropertiesHeader>
+          {nodeEditor}
+        </StyledNodeEditor>
+      );
     }
 
     // id used in onboarding
@@ -97,6 +165,7 @@ class PropertiesPanelContainer extends Component {
     return (
       <Panel id="properties-panel" title="Properties" icon={SlidersH}>
         <PropertiesPanelContent>{content}</PropertiesPanelContent>
+        <NodeEditorTooltip id="node-editor" />
       </Panel>
     );
   }

--- a/src/ui/properties/SkyboxNodeEditor.js
+++ b/src/ui/properties/SkyboxNodeEditor.js
@@ -22,35 +22,35 @@ export default class SkyboxNodeEditor extends Component {
     "Creates a visualization of an open sky and atmosphere around your scene. Also used as the environment map for your scene.";
 
   onChangeTurbidity = turbidity => {
-    this.props.editor.setProperty(this.props.node, "turbidity", turbidity);
+    this.props.editor.setPropertySelected("turbidity", turbidity);
   };
 
   onChangeRayleigh = rayleigh => {
-    this.props.editor.setProperty(this.props.node, "rayleigh", rayleigh);
+    this.props.editor.setPropertySelected("rayleigh", rayleigh);
   };
 
   onChangeLuminance = luminance => {
-    this.props.editor.setProperty(this.props.node, "luminance", luminance);
+    this.props.editor.setPropertySelected("luminance", luminance);
   };
 
   onChangeMieCoefficient = mieCoefficient => {
-    this.props.editor.setProperty(this.props.node, "mieCoefficient", mieCoefficient);
+    this.props.editor.setPropertySelected("mieCoefficient", mieCoefficient);
   };
 
   onChangeMieDirectionalG = mieDirectionalG => {
-    this.props.editor.setProperty(this.props.node, "mieDirectionalG", mieDirectionalG);
+    this.props.editor.setPropertySelected("mieDirectionalG", mieDirectionalG);
   };
 
   onChangeInclination = inclination => {
-    this.props.editor.setProperty(this.props.node, "inclination", inclination);
+    this.props.editor.setPropertySelected("inclination", inclination);
   };
 
   onChangeAzimuth = azimuth => {
-    this.props.editor.setProperty(this.props.node, "azimuth", azimuth);
+    this.props.editor.setPropertySelected("azimuth", azimuth);
   };
 
   onChangeDistance = distance => {
-    this.props.editor.setProperty(this.props.node, "distance", distance);
+    this.props.editor.setPropertySelected("distance", distance);
   };
 
   render() {

--- a/src/ui/properties/SpawnerNodeEditor.js
+++ b/src/ui/properties/SpawnerNodeEditor.js
@@ -16,11 +16,7 @@ export default class SpawnerNodeEditor extends Component {
   static description = "Spawns a model as an interactable object.";
 
   onChangeSrc = (src, { scaleToFit }) => {
-    if (scaleToFit) {
-      this.props.node.scaleToFit = scaleToFit;
-    }
-
-    this.props.editor.setProperty(this.props.node, "src", src);
+    this.props.editor.setPropertiesSelected({ scaleToFit: scaleToFit || false, src });
   };
 
   render() {

--- a/src/ui/properties/SpotLightNodeEditor.js
+++ b/src/ui/properties/SpotLightNodeEditor.js
@@ -14,7 +14,8 @@ const radToDeg = _Math.radToDeg;
 export default class SpotLightNodeEditor extends Component {
   static propTypes = {
     editor: PropTypes.object,
-    node: PropTypes.object
+    node: PropTypes.object,
+    multiEdit: PropTypes.bool
   };
 
   static iconComponent = Bullseye;
@@ -22,23 +23,23 @@ export default class SpotLightNodeEditor extends Component {
   static description = "A light which emits along a direction, illuminating objects within a cone.";
 
   onChangeColor = color => {
-    this.props.editor.setProperty(this.props.node, "color", color);
+    this.props.editor.setPropertySelected("color", color);
   };
 
   onChangeIntensity = intensity => {
-    this.props.editor.setProperty(this.props.node, "intensity", intensity);
+    this.props.editor.setPropertySelected("intensity", intensity);
   };
 
   onChangeInnerConeAngle = innerConeAngle => {
-    this.props.editor.setProperty(this.props.node, "innerConeAngle", innerConeAngle);
+    this.props.editor.setPropertySelected("innerConeAngle", innerConeAngle);
   };
 
   onChangeOuterConeAngle = outerConeAngle => {
-    this.props.editor.setProperty(this.props.node, "outerConeAngle", outerConeAngle);
+    this.props.editor.setPropertySelected("outerConeAngle", outerConeAngle);
   };
 
   onChangeRange = range => {
-    this.props.editor.setProperty(this.props.node, "range", range);
+    this.props.editor.setPropertySelected("range", range);
   };
 
   render() {

--- a/src/ui/properties/TransformPropertyGroup.js
+++ b/src/ui/properties/TransformPropertyGroup.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import { Vector3 } from "three";
 import PropTypes from "prop-types";
 import PropertyGroup from "./PropertyGroup";
 import InputGroup from "../inputs/InputGroup";
@@ -13,6 +14,7 @@ export default class TransformPropertyGroup extends Component {
 
   constructor(props) {
     super(props);
+    this.translation = new Vector3();
   }
 
   shouldComponentUpdate(nextProps) {
@@ -28,28 +30,32 @@ export default class TransformPropertyGroup extends Component {
   }
 
   onObjectsChanged = (objects, property) => {
-    if (
-      objects[0] === this.props.node &&
-      (property === "position" ||
-        property === "rotation" ||
-        property === "scale" ||
-        property === "matrix" ||
-        property == null)
-    ) {
-      this.forceUpdate();
+    for (let i = 0; i < objects.length; i++) {
+      if (
+        objects[i] === this.props.node &&
+        (property === "position" ||
+          property === "rotation" ||
+          property === "scale" ||
+          property === "matrix" ||
+          property == null)
+      ) {
+        this.forceUpdate();
+        return;
+      }
     }
   };
 
   onChangePosition = value => {
-    this.props.editor.setPosition(this.props.node, value);
+    this.translation.subVectors(value, this.props.node.position);
+    this.props.editor.translateSelected(this.translation);
   };
 
   onChangeRotation = value => {
-    this.props.editor.setRotation(this.props.node, value);
+    this.props.editor.setRotationSelected(value);
   };
 
   onChangeScale = value => {
-    this.props.editor.setScale(this.props.node, value);
+    this.props.editor.setScaleSelected(value);
   };
 
   render() {

--- a/src/ui/properties/TriggerVolumeNodeEditor.js
+++ b/src/ui/properties/TriggerVolumeNodeEditor.js
@@ -27,7 +27,8 @@ const componentOptions = [
 export default class TriggerVolumeNodeEditor extends Component {
   static propTypes = {
     editor: PropTypes.object,
-    node: PropTypes.object
+    node: PropTypes.object,
+    multiEdit: PropTypes.bool
   };
 
   static iconComponent = Running;
@@ -43,7 +44,7 @@ export default class TriggerVolumeNodeEditor extends Component {
   }
 
   onChangeTarget = target => {
-    this.props.editor.setProperties(this.props.node, {
+    this.props.editor.setPropertiesSelected({
       target,
       enterComponent: null,
       enterProperty: null,
@@ -55,8 +56,7 @@ export default class TriggerVolumeNodeEditor extends Component {
   };
 
   onChangeEnterComponent = value => {
-    const { node, editor } = this.props;
-    editor.setProperties(node, {
+    this.props.editor.setPropertiesSelected({
       enterComponent: value,
       enterProperty: null,
       enterValue: null
@@ -64,21 +64,18 @@ export default class TriggerVolumeNodeEditor extends Component {
   };
 
   onChangeEnterProperty = (value, option) => {
-    const { node, editor } = this.props;
-    editor.setProperties(node, {
+    this.props.editor.setPropertiesSelected({
       enterProperty: value,
       enterValue: option.default !== undefined ? option.default : null
     });
   };
 
   onChangeEnterValue = value => {
-    const { node, editor } = this.props;
-    editor.setProperty(node, "enterValue", value);
+    this.props.editor.setPropertySelected("enterValue", value);
   };
 
   onChangeLeaveComponent = value => {
-    const { node, editor } = this.props;
-    editor.setProperties(node, {
+    this.props.editor.setPropertiesSelected({
       leaveComponent: value,
       leaveProperty: null,
       leaveValue: null
@@ -86,16 +83,14 @@ export default class TriggerVolumeNodeEditor extends Component {
   };
 
   onChangeLeaveProperty = (value, option) => {
-    const { node, editor } = this.props;
-    editor.setProperties(node, {
+    this.props.editor.setPropertiesSelected({
       leaveProperty: value,
       leaveValue: option.default !== undefined ? option.default : null
     });
   };
 
   onChangeLeaveValue = value => {
-    const { node, editor } = this.props;
-    editor.setProperty(node, "leaveValue", value);
+    this.props.editor.setPropertySelected("leaveValue", value);
   };
 
   componentDidMount() {
@@ -113,7 +108,7 @@ export default class TriggerVolumeNodeEditor extends Component {
   }
 
   render() {
-    const { node } = this.props;
+    const { node, multiEdit } = this.props;
 
     const targetOption = this.state.options.find(o => o.value === node.target);
     const target = targetOption ? targetOption.value : null;
@@ -151,6 +146,7 @@ export default class TriggerVolumeNodeEditor extends Component {
             value={node.target}
             onChange={this.onChangeTarget}
             options={this.state.options}
+            disabled={multiEdit}
           />
         </InputGroup>
         <InputGroup name="Enter Component">
@@ -159,7 +155,7 @@ export default class TriggerVolumeNodeEditor extends Component {
             value={node.enterComponent}
             onChange={this.onChangeEnterComponent}
             options={filteredComponentOptions}
-            disabled={!target}
+            disabled={multiEdit || !target}
           />
         </InputGroup>
         <InputGroup name="Enter Property">
@@ -168,7 +164,7 @@ export default class TriggerVolumeNodeEditor extends Component {
             value={node.enterProperty}
             onChange={this.onChangeEnterProperty}
             options={filteredEnterPropertyOptions}
-            disabled={!enterComponent}
+            disabled={multiEdit || !enterComponent}
           />
         </InputGroup>
         <InputGroup name="Enter Value">
@@ -176,7 +172,7 @@ export default class TriggerVolumeNodeEditor extends Component {
             <EnterInput
               value={node.enterValue}
               onChange={this.onChangeEnterValue}
-              disabled={!(target && enterComponent && enterProperty)}
+              disabled={multiEdit || !(target && enterComponent && enterProperty)}
             />
           ) : (
             <StringInput disabled />
@@ -188,7 +184,7 @@ export default class TriggerVolumeNodeEditor extends Component {
             value={node.leaveComponent}
             onChange={this.onChangeLeaveComponent}
             options={filteredComponentOptions}
-            disabled={!target}
+            disabled={multiEdit || !target}
           />
         </InputGroup>
         <InputGroup name="Leave Property">
@@ -197,7 +193,7 @@ export default class TriggerVolumeNodeEditor extends Component {
             value={node.leaveProperty}
             onChange={this.onChangeLeaveProperty}
             options={filteredLeavePropertyOptions}
-            disabled={!leaveComponent}
+            disabled={multiEdit || !leaveComponent}
           />
         </InputGroup>
         <InputGroup name="Leave Value">
@@ -205,7 +201,7 @@ export default class TriggerVolumeNodeEditor extends Component {
             <LeaveInput
               value={node.leaveValue}
               onChange={this.onChangeLeaveValue}
-              disabled={!(target && leaveComponent && leaveProperty)}
+              disabled={multiEdit || !(target && leaveComponent && leaveProperty)}
             />
           ) : (
             <StringInput disabled />

--- a/src/ui/properties/VideoNodeEditor.js
+++ b/src/ui/properties/VideoNodeEditor.js
@@ -19,7 +19,8 @@ const distanceModelOptions = Object.values(DistanceModelType).map(v => ({ label:
 export default class VideoNodeEditor extends Component {
   static propTypes = {
     editor: PropTypes.object,
-    node: PropTypes.object
+    node: PropTypes.object,
+    multiEdit: PropTypes.bool
   };
 
   static iconComponent = Video;
@@ -28,7 +29,7 @@ export default class VideoNodeEditor extends Component {
 
   constructor(props) {
     super(props);
-    const createPropSetter = propName => value => this.props.editor.setProperty(this.props.node, propName, value);
+    const createPropSetter = propName => value => this.props.editor.setPropertySelected(propName, value);
     this.onChangeSrc = createPropSetter("src");
     this.onChangeProjection = createPropSetter("projection");
     this.onChangeControls = createPropSetter("controls");
@@ -46,7 +47,9 @@ export default class VideoNodeEditor extends Component {
   }
 
   render() {
-    const node = this.props.node;
+    const { node, multiEdit } = this.props;
+
+    // TODO: Make video node audio settings work with multi-edit
 
     return (
       <NodeEditor description={VideoNodeEditor.description} {...this.props}>
@@ -71,7 +74,7 @@ export default class VideoNodeEditor extends Component {
         <InputGroup name="Volume">
           <CompoundNumericInput value={node.volume} onChange={this.onChangeVolume} />
         </InputGroup>
-        {node.audioType === AudioType.PannerNode && (
+        {!multiEdit && node.audioType === AudioType.PannerNode && (
           <Fragment>
             <InputGroup name="Distance Model">
               <SelectInput
@@ -134,6 +137,7 @@ export default class VideoNodeEditor extends Component {
               value={node.coneInnerAngle}
               onChange={this.onChangeConeInnerAngle}
               unit="°"
+              disabled={multiEdit}
             />
             <NumericInputGroup
               name="Cone Outer Angle"
@@ -145,6 +149,7 @@ export default class VideoNodeEditor extends Component {
               value={node.coneOuterAngle}
               onChange={this.onChangeConeOuterAngle}
               unit="°"
+              disabled={multiEdit}
             />
             <InputGroup name="Cone Outer Gain">
               <CompoundNumericInput


### PR DESCRIPTION
You can now edit the properties of multiple selected objects at the same time! If the objects are of the same type you'll see all of the object properties in the properties panel. Changing the property will change all of the selected objects. Some properties such as animation may be disabled if all objects do not have the same options for that property. If you select objects with different types you will still see the transform, visibility, and name fields. Changes to the translation properties will be applied relative to the objects current position. Rotation and scale values will set absolutely.

![MultiEdit](https://user-images.githubusercontent.com/1753624/67610592-cff29b80-f748-11e9-9edc-30c6f18a9795.gif)
