### PR TITLE
Fix attribution republishing

### DIFF
--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -682,7 +682,7 @@ export default class Project extends EventEmitter {
       if (project.scene) {
         allowPromotion = project.scene.allow_promotion;
         allowRemixing = project.scene.allow_remixing;
-        creatorAttribution = project.scene.attributions.creator || creatorAttribution;
+        creatorAttribution = project.scene.attributions.creator || "";
       } else if ((!creatorAttribution || creatorAttribution.length === 0) && userInfo && userInfo.creatorAttribution) {
         creatorAttribution = userInfo.creatorAttribution;
       }

--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -682,7 +682,7 @@ export default class Project extends EventEmitter {
       if (project.scene) {
         allowPromotion = project.scene.allow_promotion;
         allowRemixing = project.scene.allow_remixing;
-        creatorAttribution = project.scene.attribution || "";
+        creatorAttribution = project.scene.attributions.creator || creatorAttribution;
       } else if ((!creatorAttribution || creatorAttribution.length === 0) && userInfo && userInfo.creatorAttribution) {
         creatorAttribution = userInfo.creatorAttribution;
       }


### PR DESCRIPTION
Currently the creator attribution is pulled from a deprecated key on the scene. This PR pulls from the correct creator attribution when it exists.

Creator attribution should then:
- Use the existing value when republishing
- Use the value saved in local storage when publishing a new scene
- For legacy scenes without a scene associated with their project (projects previously stored the scene id in the project file itself, not in the db), the value stored in the project file's metadata will be used
- Otherwise be an empty string, including when remixing an existing scene because the creator attribution is held in the parent scene