### PR TITLE
Delete creator attribution when remixing

### DIFF
--- a/src/ui/EditorContainer.js
+++ b/src/ui/EditorContainer.js
@@ -199,6 +199,7 @@ class EditorContainer extends Component {
       if (projectFile.metadata) {
         delete projectFile.metadata.sceneUrl;
         delete projectFile.metadata.sceneId;
+        delete projectFile.metadata.creatorAttribution;
       }
 
       await editor.init();


### PR DESCRIPTION
The Spoke file should contain the remixer's attribution, not the creator's. The creator's attribution is stored in the db.