### PR TITLE
Only set asset source after uploading

### DIFF
--- a/src/ui/assets/AssetDropZone.js
+++ b/src/ui/assets/AssetDropZone.js
@@ -35,8 +35,9 @@ export default function AssetDropZone({ afterUpload, uploadOptions }) {
   const [{ canDrop, isOver, isDragging }, onDropTarget] = useDrop({
     accept: [ItemTypes.File],
     drop(item) {
-      editor.setSource(editor.defaultUploadSource.id);
       onUpload(item.files).then(assets => {
+        editor.setSource(editor.defaultUploadSource.id);
+
         if (afterUpload) {
           afterUpload(assets);
         }


### PR DESCRIPTION
Before uploading, the user might not have been signed in and the My Assets source might not be enabled. This PR only sets the source after a successful upload when the user is guaranteed to be authenticated.