### PR TITLE
Reduce media api calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "three": "https://github.com/MozillaReality/three.js.git#0f9b0024725f0dd917caa54c2934a4ba1fc12c4f",
     "three-mesh-bvh": "^0.1.4",
     "url-toolkit": "^2.1.6",
+    "use-debounce": "^3.4.0",
     "use-http": "^0.2.4",
     "uuid": "^3.3.3"
   },

--- a/src/ui/assets/AssetManifestSource.js
+++ b/src/ui/assets/AssetManifestSource.js
@@ -36,6 +36,7 @@ export default class AssetManifestSource extends BaseSource {
     this.assets = [];
     this.tags = [];
     this.loaded = false;
+    this.searchDebounceTimeout = 0;
   }
 
   async load() {

--- a/src/ui/assets/KitSource.js
+++ b/src/ui/assets/KitSource.js
@@ -24,6 +24,7 @@ export default class KitSource extends BaseSource {
     this.assets = [];
     this.tags = [];
     this.loaded = false;
+    this.searchDebounceTimeout = 0;
   }
 
   async load() {

--- a/src/ui/assets/sources/ArchitectureKitSource.js
+++ b/src/ui/assets/sources/ArchitectureKitSource.js
@@ -10,5 +10,7 @@ export default class ArchitectureKitSource extends KitSource {
     this.id = "architecture-kit";
     this.name = "Architecture Kit";
     this.transformPivot = TransformPivot.Selection;
+    // Images take a while to load so we set a debounce timeout
+    this.searchDebounceTimeout = 500;
   }
 }

--- a/src/ui/assets/sources/ElementsSource.js
+++ b/src/ui/assets/sources/ElementsSource.js
@@ -14,6 +14,7 @@ export default class ElementsSource extends BaseSource {
     this.editor.addListener("settingsChanged", this.onSettingsChanged);
     this.editor.addListener("sceneGraphChanged", this.onSceneGraphChanged);
     this.disableUrl = true;
+    this.searchDebounceTimeout = 0;
   }
 
   onSettingsChanged = () => {

--- a/src/ui/assets/sources/index.js
+++ b/src/ui/assets/sources/index.js
@@ -9,6 +9,7 @@ export class BaseSource extends EventEmitter {
     this.assetPanelComponent = undefined;
     this.requiresAuthentication = false;
     this.uploadSource = false;
+    this.searchDebounceTimeout = 500;
   }
 
   search(_query, _params, _cursor, _abortSignal) {

--- a/src/ui/assets/useAssetSearch.js
+++ b/src/ui/assets/useAssetSearch.js
@@ -1,4 +1,5 @@
 import { useRef, useState, useCallback, useEffect } from "react";
+import { useDebouncedCallback } from "use-debounce";
 
 function useIsMounted() {
   const ref = useRef(false);
@@ -139,12 +140,14 @@ export function useAssetSearch(source, initialParams = {}, initialResults = [], 
     };
   }, [source, loadAsync, params]);
 
+  const [debouncedLoadAsync] = useDebouncedCallback(loadAsync, source.searchDebounceTimeout);
+
   const setParams = useCallback(
     nextParams => {
-      loadAsync(nextParams);
+      debouncedLoadAsync(nextParams);
       setParamsInternal(nextParams);
     },
-    [loadAsync, setParamsInternal]
+    [debouncedLoadAsync, setParamsInternal]
   );
 
   return {

--- a/src/ui/inputs/AudioInput.js
+++ b/src/ui/inputs/AudioInput.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import StringInput from "./StringInput";
+import { ControlledStringInput } from "./StringInput";
 import { useDrop } from "react-dnd";
 import { ItemTypes } from "../dnd";
 import useUpload from "../assets/useUpload";
@@ -33,7 +33,13 @@ export default function AudioInput({ onChange, ...rest }) {
   });
 
   return (
-    <StringInput ref={dropRef} onChange={onChange} error={isOver && !canDrop} canDrop={isOver && canDrop} {...rest} />
+    <ControlledStringInput
+      ref={dropRef}
+      onChange={onChange}
+      error={isOver && !canDrop}
+      canDrop={isOver && canDrop}
+      {...rest}
+    />
   );
 }
 

--- a/src/ui/inputs/ImageInput.js
+++ b/src/ui/inputs/ImageInput.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import StringInput from "./StringInput";
+import { ControlledStringInput } from "./StringInput";
 import { useDrop } from "react-dnd";
 import { ItemTypes } from "../dnd";
 import useUpload from "../assets/useUpload";
@@ -33,7 +33,13 @@ export default function ImageInput({ onChange, ...rest }) {
   });
 
   return (
-    <StringInput ref={dropRef} onChange={onChange} error={isOver && !canDrop} canDrop={isOver && canDrop} {...rest} />
+    <ControlledStringInput
+      ref={dropRef}
+      onChange={onChange}
+      error={isOver && !canDrop}
+      canDrop={isOver && canDrop}
+      {...rest}
+    />
   );
 }
 

--- a/src/ui/inputs/ModelInput.js
+++ b/src/ui/inputs/ModelInput.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import StringInput from "./StringInput";
+import { ControlledStringInput } from "./StringInput";
 import { useDrop } from "react-dnd";
 import { ItemTypes } from "../dnd";
 import useUpload from "../assets/useUpload";
@@ -33,7 +33,7 @@ export default function ModelInput({ onChange, ...rest }) {
   });
 
   return (
-    <StringInput
+    <ControlledStringInput
       ref={dropRef}
       onChange={(value, e) => onChange(value, {}, e)}
       error={isOver && !canDrop}

--- a/src/ui/inputs/StringInput.js
+++ b/src/ui/inputs/StringInput.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import Input from "./Input";
@@ -31,3 +31,59 @@ StringInput.propTypes = {
 };
 
 export default StringInput;
+
+export const ControlledStringInput = React.forwardRef(({ onChange, value, ...rest }, ref) => {
+  const inputRef = useRef(ref);
+
+  const [tempValue, setTempValue] = useState(value);
+
+  const onKeyUp = useCallback(e => {
+    if (e.key === "Enter" || e.key === "Escape") {
+      inputRef.current.blur();
+    }
+  }, []);
+
+  useEffect(() => {
+    setTempValue(value);
+  }, [value]);
+
+  const onBlur = useCallback(() => {
+    onChange(tempValue);
+  }, [onChange, tempValue]);
+
+  const onChangeValue = useCallback(
+    e => {
+      setTempValue(e.target.value);
+    },
+    [setTempValue]
+  );
+
+  return (
+    <StyledStringInput
+      ref={inputRef}
+      onChange={onChangeValue}
+      onBlur={onBlur}
+      onKeyUp={onKeyUp}
+      value={tempValue}
+      {...rest}
+    />
+  );
+});
+
+ControlledStringInput.displayName = "ControlledStringInput";
+
+ControlledStringInput.defaultProps = {
+  value: "",
+  onChange: () => {},
+  type: "text",
+  required: false
+};
+
+ControlledStringInput.propTypes = {
+  className: PropTypes.string,
+  value: PropTypes.string,
+  type: PropTypes.string,
+  required: PropTypes.bool,
+  placeholder: PropTypes.string,
+  onChange: PropTypes.func
+};

--- a/src/ui/inputs/VideoInput.js
+++ b/src/ui/inputs/VideoInput.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import StringInput from "./StringInput";
+import { ControlledStringInput } from "./StringInput";
 import { useDrop } from "react-dnd";
 import { ItemTypes } from "../dnd";
 import useUpload from "../assets/useUpload";
@@ -33,7 +33,13 @@ export default function VideoInput({ onChange, ...rest }) {
   });
 
   return (
-    <StringInput ref={dropRef} onChange={onChange} error={isOver && !canDrop} canDrop={isOver && canDrop} {...rest} />
+    <ControlledStringInput
+      ref={dropRef}
+      onChange={onChange}
+      error={isOver && !canDrop}
+      canDrop={isOver && canDrop}
+      {...rest}
+    />
   );
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13354,6 +13354,11 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-debounce@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-3.4.0.tgz#e61653fd4daad9beaa6e4695bc1d3fbd35f7e5b3"
+  integrity sha512-FSUfs/x7eJUusqvbk/UboMlWKQFBEGTegqK2tvm8+59bcbs77f0DeAy4MuychfxN7E+6rxXDpbv41Kq+aSJPow==
+
 use-http@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/use-http/-/use-http-0.2.4.tgz#d107b5c809d6f9fc4ed44d9a37cf7fa37cb94a6e"


### PR DESCRIPTION
Reduce media API calls in the assets panel and when changing media src properties.

The asset panel now debounces calls for 500ms for any requests hitting the media API (and the architecture kit because images take a while to load and it makes for a better UX).

Changes to the media src property now only applies on blur. Pressing the escape or enter key blurs the input and triggers the change.