### PR TITLE
Don't serialize and send console arguments to Sentry.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,15 @@ import { initTelemetry } from "./telemetry";
 if (configs.SENTRY_DSN) {
   Sentry.init({
     dsn: configs.SENTRY_DSN,
-    release: process.env.BUILD_VERSION
+    release: process.env.BUILD_VERSION,
+    beforeBreadcrumb(breadcrumb) {
+      // Just send the console message and avoid expensive argument serialization.
+      if (breadcrumb.category === "console") {
+        delete breadcrumb.data;
+      }
+
+      return breadcrumb;
+    }
   });
 }
 


### PR DESCRIPTION
Sentry was calling `toJSON` on any argument passed to console.log/warn/error. This in turn was calling `THREE.Texture.toJSON` in the `BatchManager` which then converted the image to a data URL. We don't want the extra arguments in our sentry logs anyways. Hopefully this fixes the scene load performance on production.