### PR TITLE
Don't require author in asset extras

### DIFF
--- a/src/editor/nodes/ModelNode.js
+++ b/src/editor/nodes/ModelNode.js
@@ -112,7 +112,7 @@ export default class ModelNode extends EditorNodeMixin(Model) {
 
     if (sketchfabExtras) {
       const name = sketchfabExtras.title;
-      const author = sketchfabExtras.author.replace(/ \(http.+\)/, "");
+      const author = sketchfabExtras.author ? sketchfabExtras.author.replace(/ \(http.+\)/, "") : "";
       const url = sketchfabExtras.source || this._canonicalUrl;
       clonedScene.name = name;
       this.attribution = { name, author, url };


### PR DESCRIPTION
Current code assumes if `extras` exists on `asset` that it must have an `author`. The Hubs Blender Exporter now includes `"HUBS_blenderExporterVersion" : "0.0.3"` in asset extras, but not an author, which prevents Spoke from loading any GLTFs created by that exporter.