### PR TITLE
Pass through MOZ_hubs_components unmodified

### DIFF
--- a/src/editor/gltf/GLTFLoader.js
+++ b/src/editor/gltf/GLTFLoader.js
@@ -1927,14 +1927,11 @@ class GLTFLoader {
   }
 
   addUnknownExtensionsToUserData(object, objectDef) {
-    // Add unknown glTF extensions to an object's userData.
-
-    if (!this.options.addUnknownExtensionsToUserData) {
-      return;
-    }
-
     for (const name in objectDef.extensions) {
-      if (!this.knownExtensions.has(name)) {
+      if (
+        name == "MOZ_hubs_components" ||
+        (this.options.addUnknownExtensionsToUserData && !this.knownExtensions.has(name))
+      ) {
         object.userData.gltfExtensions = object.userData.gltfExtensions || {};
         object.userData.gltfExtensions[name] = objectDef.extensions[name];
       }


### PR DESCRIPTION
This will only actually work correctly for components that do not contain index-based references to other nodes in the GLTF. To support those components Spoke needs to become aware of the actual component schema so it can rewrite those indices. As is it should still provide a lot of utility for being able to compose "smarter" objects from blender (such as using `uv-scroll`, `loop-animation`, etc)