### PR TITLE
Add "alpha mode" setting for images

### DIFF
--- a/src/editor/nodes/ImageNode.js
+++ b/src/editor/nodes/ImageNode.js
@@ -24,8 +24,8 @@ export default class ImageNode extends EditorNodeMixin(Image) {
       (async () => {
         await node.load(src, onError);
         node.controls = controls || false;
-        node.transparencyMode = transparencyMode === undefined ? ImageTransparencyMode.Alpha : transparencyMode;
         node.alphaCutoff = alphaCutoff || 0.5;
+        node.transparencyMode = transparencyMode === undefined ? ImageTransparencyMode.Blend : transparencyMode;
         node.projection = projection;
       })()
     );
@@ -135,7 +135,7 @@ export default class ImageNode extends EditorNodeMixin(Image) {
       transparencyMode: this.transparencyMode,
       projection: this.projection
     };
-    if (this.transparencyMode === ImageTransparencyMode.Cutout) {
+    if (this.transparencyMode === ImageTransparencyMode.Mask) {
       imageData.alphaCutoff = this.alphaCutoff;
     }
 

--- a/src/editor/nodes/ImageNode.js
+++ b/src/editor/nodes/ImageNode.js
@@ -24,8 +24,8 @@ export default class ImageNode extends EditorNodeMixin(Image) {
       (async () => {
         await node.load(src, onError);
         node.controls = controls || false;
-        node.alphaCutoff = alphaCutoff || 0.5;
         node.transparencyMode = transparencyMode === undefined ? ImageTransparencyMode.Blend : transparencyMode;
+        node.alphaCutoff = alphaCutoff === undefined ? 0.5 : alphaCutoff;
         node.projection = projection;
       })()
     );

--- a/src/editor/nodes/ImageNode.js
+++ b/src/editor/nodes/ImageNode.js
@@ -1,5 +1,5 @@
 import EditorNodeMixin from "./EditorNodeMixin";
-import Image, { ImageTransparencyMode } from "../objects/Image";
+import Image, { ImageAlphaMode } from "../objects/Image";
 import spokeLogoSrc from "../../assets/spoke-icon.png";
 import { RethrownError } from "../utils/errors";
 import { getObjectPerfIssues, maybeAddLargeFileIssue } from "../utils/performance";
@@ -16,15 +16,13 @@ export default class ImageNode extends EditorNodeMixin(Image) {
   static async deserialize(editor, json, loadAsync, onError) {
     const node = await super.deserialize(editor, json);
 
-    const { src, projection, controls, transparencyMode, alphaCutoff } = json.components.find(
-      c => c.name === "image"
-    ).props;
+    const { src, projection, controls, alphaMode, alphaCutoff } = json.components.find(c => c.name === "image").props;
 
     loadAsync(
       (async () => {
         await node.load(src, onError);
         node.controls = controls || false;
-        node.transparencyMode = transparencyMode === undefined ? ImageTransparencyMode.Blend : transparencyMode;
+        node.alphaMode = alphaMode === undefined ? ImageAlphaMode.Blend : alphaMode;
         node.alphaCutoff = alphaCutoff === undefined ? 0.5 : alphaCutoff;
         node.projection = projection;
       })()
@@ -107,7 +105,7 @@ export default class ImageNode extends EditorNodeMixin(Image) {
     super.copy(source, recursive);
 
     this.controls = source.controls;
-    this.transparencyMode = source.transparencyMode;
+    this.alphaMode = source.alphaMode;
     this.alphaCutoff = source.alphaCutoff;
     this._canonicalUrl = source._canonicalUrl;
 
@@ -119,7 +117,7 @@ export default class ImageNode extends EditorNodeMixin(Image) {
       image: {
         src: this._canonicalUrl,
         controls: this.controls,
-        transparencyMode: this.transparencyMode,
+        alphaMode: this.alphaMode,
         alphaCutoff: this.alphaCutoff,
         projection: this.projection
       }
@@ -132,10 +130,10 @@ export default class ImageNode extends EditorNodeMixin(Image) {
     const imageData = {
       src: this._canonicalUrl,
       controls: this.controls,
-      transparencyMode: this.transparencyMode,
+      alphaMode: this.alphaMode,
       projection: this.projection
     };
-    if (this.transparencyMode === ImageTransparencyMode.Mask) {
+    if (this.alphaMode === ImageAlphaMode.Mask) {
       imageData.alphaCutoff = this.alphaCutoff;
     }
 

--- a/src/editor/nodes/ImageNode.js
+++ b/src/editor/nodes/ImageNode.js
@@ -16,12 +16,13 @@ export default class ImageNode extends EditorNodeMixin(Image) {
   static async deserialize(editor, json, loadAsync, onError) {
     const node = await super.deserialize(editor, json);
 
-    const { src, projection, controls } = json.components.find(c => c.name === "image").props;
+    const { src, projection, controls, transparent } = json.components.find(c => c.name === "image").props;
 
     loadAsync(
       (async () => {
         await node.load(src, onError);
         node.controls = controls || false;
+        node.transparent = transparent === undefined ? true : transparent;
         node.projection = projection;
       })()
     );
@@ -34,6 +35,7 @@ export default class ImageNode extends EditorNodeMixin(Image) {
 
     this._canonicalUrl = "";
     this.controls = true;
+    this.transparent = false;
   }
 
   get src() {
@@ -103,6 +105,7 @@ export default class ImageNode extends EditorNodeMixin(Image) {
     super.copy(source, recursive);
 
     this.controls = source.controls;
+    this.transparent = source.transparent;
     this._canonicalUrl = source._canonicalUrl;
 
     return this;
@@ -113,6 +116,7 @@ export default class ImageNode extends EditorNodeMixin(Image) {
       image: {
         src: this._canonicalUrl,
         controls: this.controls,
+        transparent: this.transparent,
         projection: this.projection
       }
     });
@@ -123,6 +127,7 @@ export default class ImageNode extends EditorNodeMixin(Image) {
     this.addGLTFComponent("image", {
       src: this._canonicalUrl,
       controls: this.controls,
+      transparent: this.transparent,
       projection: this.projection
     });
     this.addGLTFComponent("networked", {

--- a/src/editor/objects/Image.js
+++ b/src/editor/objects/Image.js
@@ -15,7 +15,7 @@ export const ImageProjection = {
   Equirectangular360: "360-equirectangular"
 };
 
-export const ImageTransparencyMode = {
+export const ImageAlphaMode = {
   None: "none",
   Blend: "blend",
   Mask: "mask"
@@ -26,14 +26,14 @@ export default class Image extends Object3D {
     super();
     this._src = null;
     this._projection = "flat";
-    this._transparencyMode = ImageTransparencyMode.None;
+    this._alphaMode = ImageAlphaMode.None;
     this._alphaCutoff = 0.5;
 
     const geometry = new PlaneBufferGeometry();
     const material = new MeshBasicMaterial();
     material.side = DoubleSide;
-    material.transparent = this.transparencyMode === ImageTransparencyMode.Blend;
-    material.alphaTest = this.transparencyMode === ImageTransparencyMode.Mask ? this._alphaCutoff : 0;
+    material.transparent = this.alphaMode === ImageAlphaMode.Blend;
+    material.alphaTest = this.alphaMode === ImageAlphaMode.Mask ? this._alphaCutoff : 0;
     this._mesh = new Mesh(geometry, material);
     this._mesh.name = "ImageMesh";
     this.add(this._mesh);
@@ -52,14 +52,14 @@ export default class Image extends Object3D {
     return loadTexture(src);
   }
 
-  get transparencyMode() {
-    return this._transparencyMode;
+  get alphaMode() {
+    return this._alphaMode;
   }
 
-  set transparencyMode(v) {
-    this._transparencyMode = v;
-    this._mesh.material.transparent = v === ImageTransparencyMode.Blend;
-    this._mesh.material.alphaTest = v === ImageTransparencyMode.Mask ? this.alphaCutoff : 0;
+  set alphaMode(v) {
+    this._alphaMode = v;
+    this._mesh.material.transparent = v === ImageAlphaMode.Blend;
+    this._mesh.material.alphaTest = v === ImageAlphaMode.Mask ? this.alphaCutoff : 0;
     this._mesh.material.needsUpdate = true;
   }
 
@@ -93,8 +93,8 @@ export default class Image extends Object3D {
 
     material.map = this._texture;
 
-    material.transparent = this.transparencyMode === ImageTransparencyMode.Blend;
-    material.alphaTest = this.transparencyMode === ImageTransparencyMode.Mask ? this._alphaCutoff : 0;
+    material.transparent = this.alphaMode === ImageAlphaMode.Blend;
+    material.alphaTest = this.alphaMode === ImageAlphaMode.Mask ? this._alphaCutoff : 0;
 
     this._projection = projection;
 
@@ -135,8 +135,8 @@ export default class Image extends Object3D {
 
     this.onResize();
 
-    material.transparent = this.transparencyMode === ImageTransparencyMode.Blend;
-    material.alphaTest = this.transparencyMode === ImageTransparencyMode.Mask ? this._alphaCutoff : 0;
+    material.transparent = this.alphaMode === ImageAlphaMode.Blend;
+    material.alphaTest = this.alphaMode === ImageAlphaMode.Mask ? this._alphaCutoff : 0;
 
     this._mesh.material.map = this._texture;
     this._mesh.material.needsUpdate = true;

--- a/src/editor/objects/Image.js
+++ b/src/editor/objects/Image.js
@@ -16,7 +16,7 @@ export const ImageProjection = {
 };
 
 export const ImageAlphaMode = {
-  None: "none",
+  Opaque: "opaque",
   Blend: "blend",
   Mask: "mask"
 };
@@ -26,7 +26,7 @@ export default class Image extends Object3D {
     super();
     this._src = null;
     this._projection = "flat";
-    this._alphaMode = ImageAlphaMode.None;
+    this._alphaMode = ImageAlphaMode.Opaque;
     this._alphaCutoff = 0.5;
 
     const geometry = new PlaneBufferGeometry();

--- a/src/editor/objects/Image.js
+++ b/src/editor/objects/Image.js
@@ -6,7 +6,6 @@ import {
   Mesh,
   sRGBEncoding,
   LinearFilter,
-  RGBAFormat,
   PlaneBufferGeometry
 } from "three";
 import loadTexture from "../utils/loadTexture";
@@ -21,10 +20,12 @@ export default class Image extends Object3D {
     super();
     this._src = null;
     this._projection = "flat";
+    this._transparent = false;
 
     const geometry = new PlaneBufferGeometry();
     const material = new MeshBasicMaterial();
     material.side = DoubleSide;
+    material.transparent = this._transparent;
     this._mesh = new Mesh(geometry, material);
     this._mesh.name = "ImageMesh";
     this.add(this._mesh);
@@ -41,6 +42,15 @@ export default class Image extends Object3D {
 
   loadTexture(src) {
     return loadTexture(src);
+  }
+
+  get transparent() {
+    return this._transparent;
+  }
+
+  set transparent(v) {
+    this._transparent = v;
+    this._mesh.material.transparent = v;
   }
 
   get projection() {
@@ -63,9 +73,7 @@ export default class Image extends Object3D {
 
     material.map = this._texture;
 
-    if (this._texture && this._texture.format === RGBAFormat) {
-      material.transparent = true;
-    }
+    material.transparent = this._transparent;
 
     this._projection = projection;
 
@@ -106,9 +114,7 @@ export default class Image extends Object3D {
 
     this.onResize();
 
-    if (texture.format === RGBAFormat) {
-      this._mesh.material.transparent = true;
-    }
+    this._mesh.material.transparent = this._transparent;
 
     this._mesh.material.map = this._texture;
     this._mesh.material.needsUpdate = true;

--- a/src/editor/objects/Image.js
+++ b/src/editor/objects/Image.js
@@ -15,17 +15,25 @@ export const ImageProjection = {
   Equirectangular360: "360-equirectangular"
 };
 
+export const ImageTransparencyMode = {
+  None: "none",
+  Alpha: "alpha",
+  Cutout: "cutout"
+};
+
 export default class Image extends Object3D {
   constructor() {
     super();
     this._src = null;
     this._projection = "flat";
-    this._transparent = false;
+    this._transparencyMode = ImageTransparencyMode.None;
+    this._alphaCutoff = 0.5;
 
     const geometry = new PlaneBufferGeometry();
     const material = new MeshBasicMaterial();
     material.side = DoubleSide;
-    material.transparent = this._transparent;
+    material.transparent = this.transparencyMode === ImageTransparencyMode.Alpha;
+    material.alphaTest = this.transparencyMode === ImageTransparencyMode.Cutout ? this._alphaCutoff : 0;
     this._mesh = new Mesh(geometry, material);
     this._mesh.name = "ImageMesh";
     this.add(this._mesh);
@@ -44,13 +52,25 @@ export default class Image extends Object3D {
     return loadTexture(src);
   }
 
-  get transparent() {
-    return this._transparent;
+  get transparencyMode() {
+    return this._transparencyMode;
   }
 
-  set transparent(v) {
-    this._transparent = v;
-    this._mesh.material.transparent = v;
+  set transparencyMode(v) {
+    this._transparencyMode = v;
+    this._mesh.material.transparent = v === ImageTransparencyMode.Alpha;
+    this._mesh.material.alphaTest = v === ImageTransparencyMode.Cutout ? this.alphaCutoff : 0;
+    this._mesh.material.needsUpdate = true;
+  }
+
+  get alphaCutoff() {
+    return this._alphaCutoff;
+  }
+
+  set alphaCutoff(v) {
+    this._alphaCutoff = v;
+    this._mesh.material.alphaTest = v;
+    this._mesh.material.needsUpdate = true;
   }
 
   get projection() {
@@ -73,7 +93,8 @@ export default class Image extends Object3D {
 
     material.map = this._texture;
 
-    material.transparent = this._transparent;
+    material.transparent = this.transparencyMode === ImageTransparencyMode.Alpha;
+    material.alphaTest = this.transparencyMode === ImageTransparencyMode.Cutout ? this._alphaCutoff : 0;
 
     this._projection = projection;
 
@@ -114,7 +135,8 @@ export default class Image extends Object3D {
 
     this.onResize();
 
-    this._mesh.material.transparent = this._transparent;
+    material.transparent = this.transparencyMode === ImageTransparencyMode.Alpha;
+    material.alphaTest = this.transparencyMode === ImageTransparencyMode.Cutout ? this._alphaCutoff : 0;
 
     this._mesh.material.map = this._texture;
     this._mesh.material.needsUpdate = true;

--- a/src/editor/objects/Image.js
+++ b/src/editor/objects/Image.js
@@ -17,8 +17,8 @@ export const ImageProjection = {
 
 export const ImageTransparencyMode = {
   None: "none",
-  Alpha: "alpha",
-  Cutout: "cutout"
+  Blend: "blend",
+  Mask: "mask"
 };
 
 export default class Image extends Object3D {
@@ -32,8 +32,8 @@ export default class Image extends Object3D {
     const geometry = new PlaneBufferGeometry();
     const material = new MeshBasicMaterial();
     material.side = DoubleSide;
-    material.transparent = this.transparencyMode === ImageTransparencyMode.Alpha;
-    material.alphaTest = this.transparencyMode === ImageTransparencyMode.Cutout ? this._alphaCutoff : 0;
+    material.transparent = this.transparencyMode === ImageTransparencyMode.Blend;
+    material.alphaTest = this.transparencyMode === ImageTransparencyMode.Mask ? this._alphaCutoff : 0;
     this._mesh = new Mesh(geometry, material);
     this._mesh.name = "ImageMesh";
     this.add(this._mesh);
@@ -58,8 +58,8 @@ export default class Image extends Object3D {
 
   set transparencyMode(v) {
     this._transparencyMode = v;
-    this._mesh.material.transparent = v === ImageTransparencyMode.Alpha;
-    this._mesh.material.alphaTest = v === ImageTransparencyMode.Cutout ? this.alphaCutoff : 0;
+    this._mesh.material.transparent = v === ImageTransparencyMode.Blend;
+    this._mesh.material.alphaTest = v === ImageTransparencyMode.Mask ? this.alphaCutoff : 0;
     this._mesh.material.needsUpdate = true;
   }
 
@@ -93,8 +93,8 @@ export default class Image extends Object3D {
 
     material.map = this._texture;
 
-    material.transparent = this.transparencyMode === ImageTransparencyMode.Alpha;
-    material.alphaTest = this.transparencyMode === ImageTransparencyMode.Cutout ? this._alphaCutoff : 0;
+    material.transparent = this.transparencyMode === ImageTransparencyMode.Blend;
+    material.alphaTest = this.transparencyMode === ImageTransparencyMode.Mask ? this._alphaCutoff : 0;
 
     this._projection = projection;
 
@@ -135,8 +135,8 @@ export default class Image extends Object3D {
 
     this.onResize();
 
-    material.transparent = this.transparencyMode === ImageTransparencyMode.Alpha;
-    material.alphaTest = this.transparencyMode === ImageTransparencyMode.Cutout ? this._alphaCutoff : 0;
+    material.transparent = this.transparencyMode === ImageTransparencyMode.Blend;
+    material.alphaTest = this.transparencyMode === ImageTransparencyMode.Mask ? this._alphaCutoff : 0;
 
     this._mesh.material.map = this._texture;
     this._mesh.material.needsUpdate = true;

--- a/src/ui/layout/Tooltip.js
+++ b/src/ui/layout/Tooltip.js
@@ -50,6 +50,8 @@ export const TooltipContainer = styled.div`
   overflow-wrap: break-word;
   user-select: none;
   text-align: center;
+  white-space: pre-wrap;
+}
 `;
 
 export function InfoTooltip({ info, children, ...rest }) {

--- a/src/ui/properties/ImageNodeEditor.js
+++ b/src/ui/properties/ImageNodeEditor.js
@@ -4,19 +4,23 @@ import NodeEditor from "./NodeEditor";
 import InputGroup from "../inputs/InputGroup";
 import SelectInput from "../inputs/SelectInput";
 import BooleanInput from "../inputs/BooleanInput";
-import { ImageProjection } from "../../editor/objects/Image";
+import NumericInputGroup from "../inputs/NumericInputGroup";
+import { ImageProjection, ImageTransparencyMode } from "../../editor/objects/Image";
 import ImageInput from "../inputs/ImageInput";
 import { Image } from "styled-icons/fa-solid/Image";
 import useSetPropertySelected from "./useSetPropertySelected";
 
-const imageProjectionOptions = Object.values(ImageProjection).map(v => ({ label: v, value: v }));
+const mapValue = v => ({ label: v, value: v });
+const imageProjectionOptions = Object.values(ImageProjection).map(mapValue);
+const imageTransparencyOptions = Object.values(ImageTransparencyMode).map(mapValue);
 
 export default function ImageNodeEditor(props) {
   const { editor, node } = props;
   const onChangeSrc = useSetPropertySelected(editor, "src");
   const onChangeControls = useSetPropertySelected(editor, "controls");
   const onChangeProjection = useSetPropertySelected(editor, "projection");
-  const onChangeTransparent = useSetPropertySelected(editor, "transparent");
+  const onChangeTransparencyMode = useSetPropertySelected(editor, "transparencyMode");
+  const onChangeAlphaCutoff = useSetPropertySelected(editor, "alphaCutoff");
 
   return (
     <NodeEditor description={ImageNodeEditor.description} {...props}>
@@ -26,9 +30,34 @@ export default function ImageNodeEditor(props) {
       <InputGroup name="Controls" info="Toggle the visibility of the media controls in Hubs.">
         <BooleanInput value={node.controls} onChange={onChangeControls} />
       </InputGroup>
-      <InputGroup name="Transparent" info="Enable transparency">
-        <BooleanInput value={node.transparent} onChange={onChangeTransparent} />
+      <InputGroup
+        name="Transparency Mode"
+        info={`How to apply transparency:
+'none' = no transparency
+'alpha' = use the images alpha channel
+'cutout' = Use a specified cutoff value for on/off transparency (more performant)
+`}
+      >
+        <SelectInput
+          options={imageTransparencyOptions}
+          value={node.transparencyMode}
+          onChange={onChangeTransparencyMode}
+        />
       </InputGroup>
+
+      {node.transparencyMode === ImageTransparencyMode.Cutout && (
+        <NumericInputGroup
+          name="Alpha Cutoff"
+          info="Pixels with alpha values lower than this will be transparent"
+          min={0}
+          max={1}
+          smallStep={0.01}
+          mediumStep={0.1}
+          largeStep={0.25}
+          value={node.alphaCutoff}
+          onChange={onChangeAlphaCutoff}
+        />
+      )}
       <InputGroup name="Projection">
         <SelectInput options={imageProjectionOptions} value={node.projection} onChange={onChangeProjection} />
       </InputGroup>

--- a/src/ui/properties/ImageNodeEditor.js
+++ b/src/ui/properties/ImageNodeEditor.js
@@ -45,7 +45,7 @@ export default function ImageNodeEditor(props) {
         />
       </InputGroup>
 
-      {node.transparencyMode === ImageTransparencyMode.Cutout && (
+      {node.transparencyMode === ImageTransparencyMode.Mask && (
         <NumericInputGroup
           name="Alpha Cutoff"
           info="Pixels with alpha values lower than this will be transparent"

--- a/src/ui/properties/ImageNodeEditor.js
+++ b/src/ui/properties/ImageNodeEditor.js
@@ -5,21 +5,21 @@ import InputGroup from "../inputs/InputGroup";
 import SelectInput from "../inputs/SelectInput";
 import BooleanInput from "../inputs/BooleanInput";
 import NumericInputGroup from "../inputs/NumericInputGroup";
-import { ImageProjection, ImageTransparencyMode } from "../../editor/objects/Image";
+import { ImageProjection, ImageAlphaMode } from "../../editor/objects/Image";
 import ImageInput from "../inputs/ImageInput";
 import { Image } from "styled-icons/fa-solid/Image";
 import useSetPropertySelected from "./useSetPropertySelected";
 
 const mapValue = v => ({ label: v, value: v });
 const imageProjectionOptions = Object.values(ImageProjection).map(mapValue);
-const imageTransparencyOptions = Object.values(ImageTransparencyMode).map(mapValue);
+const imageTransparencyOptions = Object.values(ImageAlphaMode).map(mapValue);
 
 export default function ImageNodeEditor(props) {
   const { editor, node } = props;
   const onChangeSrc = useSetPropertySelected(editor, "src");
   const onChangeControls = useSetPropertySelected(editor, "controls");
   const onChangeProjection = useSetPropertySelected(editor, "projection");
-  const onChangeTransparencyMode = useSetPropertySelected(editor, "transparencyMode");
+  const onChangeTransparencyMode = useSetPropertySelected(editor, "alphaMode");
   const onChangeAlphaCutoff = useSetPropertySelected(editor, "alphaCutoff");
 
   return (
@@ -33,19 +33,14 @@ export default function ImageNodeEditor(props) {
       <InputGroup
         name="Transparency Mode"
         info={`How to apply transparency:
-'none' = no transparency
-'alpha' = use the images alpha channel
-'cutout' = Use a specified cutoff value for on/off transparency (more performant)
+'opaque' = no transparency
+'blend' = use the images alpha channel
+'mask' = Use a specified cutoff value for on/off transparency (more performant)
 `}
       >
-        <SelectInput
-          options={imageTransparencyOptions}
-          value={node.transparencyMode}
-          onChange={onChangeTransparencyMode}
-        />
+        <SelectInput options={imageTransparencyOptions} value={node.alphaMode} onChange={onChangeTransparencyMode} />
       </InputGroup>
-
-      {node.transparencyMode === ImageTransparencyMode.Mask && (
+      {node.alphaMode === ImageAlphaMode.Mask && (
         <NumericInputGroup
           name="Alpha Cutoff"
           info="Pixels with alpha values lower than this will be transparent"

--- a/src/ui/properties/ImageNodeEditor.js
+++ b/src/ui/properties/ImageNodeEditor.js
@@ -16,6 +16,7 @@ export default function ImageNodeEditor(props) {
   const onChangeSrc = useSetPropertySelected(editor, "src");
   const onChangeControls = useSetPropertySelected(editor, "controls");
   const onChangeProjection = useSetPropertySelected(editor, "projection");
+  const onChangeTransparent = useSetPropertySelected(editor, "transparent");
 
   return (
     <NodeEditor description={ImageNodeEditor.description} {...props}>
@@ -24,6 +25,9 @@ export default function ImageNodeEditor(props) {
       </InputGroup>
       <InputGroup name="Controls" info="Toggle the visibility of the media controls in Hubs.">
         <BooleanInput value={node.controls} onChange={onChangeControls} />
+      </InputGroup>
+      <InputGroup name="Transparent" info="Enable transparency">
+        <BooleanInput value={node.transparent} onChange={onChangeTransparent} />
       </InputGroup>
       <InputGroup name="Projection">
         <SelectInput options={imageProjectionOptions} value={node.projection} onChange={onChangeProjection} />


### PR DESCRIPTION
Adds the option to set transparency mode for images. By default new image elements will be set to "none". Any existing images will default to "alpha" to preserve the original behavior. Hubs is similarly configured to load media components without this setting defaulting to the old behavior (alpha).

![image](https://user-images.githubusercontent.com/130735/86421625-95ee7780-bc8f-11ea-966e-ca00fd7522dc.png)

Hubs PR https://github.com/mozilla/hubs/pull/2605