### PR TITLE
Fix bug that makes it impossible to disable teleporting

### DIFF
--- a/src/ui/properties/WayPointNodeEditor.js
+++ b/src/ui/properties/WayPointNodeEditor.js
@@ -10,7 +10,7 @@ const messages = {
   "waypoint.label-canBeOccupied": "Can be occupied",
   "waypoint.label-canBeClicked": "Clickable",
   "waypoint.label-willDisableMotion": "Disable Motion",
-  "waypoint.label-willDisableTeleport": "Disable Teleporting",
+  "waypoint.label-willDisableTeleporting": "Disable Teleporting",
   "waypoint.label-snapToNavMesh": "Snap to floor plan",
   "waypoint.label-willMaintainInitialOrientation": "Maintain initial orientation",
   "waypoint.description-canBeSpawnPoint": "Avatars may be teleported to this waypoint when entering the scene",
@@ -19,7 +19,7 @@ const messages = {
   "waypoint.description-canBeClicked":
     "This waypoint will be visible in pause mode and clicking on it will teleport you to it",
   "waypoint.description-willDisableMotion": "Avatars will not be able to move after using this waypoint",
-  "waypoint.description-willDisableTeleport": "Avatars will not be able to teleport after using this waypoint",
+  "waypoint.description-willDisableTeleporting": "Avatars will not be able to teleport after using this waypoint",
   "waypoint.description-snapToNavMesh":
     "Avatars will move as close as they can to this waypoint but will not leave the ground",
   "waypoint.description-willMaintainInitialOrientation":
@@ -31,7 +31,7 @@ const propertyNames = [
   "canBeOccupied",
   "canBeClicked",
   "willDisableMotion",
-  "willDisableTeleport",
+  "willDisableTeleporting",
   "snapToNavMesh",
   "willMaintainInitialOrientation"
 ];


### PR DESCRIPTION
Fix https://github.com/mozilla/Spoke/issues/996

There was a typo in the node editor for waypoints that prevented users from disabling teleport.

In Spoke we had a mix of `willDisableTeleporting` and `willDisableTeleport` :
```js
./test/integration/snapshots/Editor.test.js.md:2114:                willDisableTeleporting: false,
./test/fixtures/V4TestScene.spoke:1:[Omitted long matching line]
./src/editor/nodes/WayPointNode.js:31:    this.willDisableTeleporting = false;
./src/editor/nodes/WayPointNode.js:53:    this.willDisableTeleporting = source.willDisableTeleporting;
./src/editor/nodes/WayPointNode.js:76:        willDisableTeleporting: this.willDisableTeleporting,
./src/editor/nodes/WayPointNode.js:92:    node.willDisableTeleporting = waypoint.props.willDisableTeleporting;
./src/editor/nodes/WayPointNode.js:106:      willDisableTeleporting: this.willDisableTeleporting,
./src/ui/properties/WayPointNodeEditor.js:13:  "waypoint.label-willDisableTeleport": "Disable Teleporting",
./src/ui/properties/WayPointNodeEditor.js:22:  "waypoint.description-willDisableTeleport": "Avatars will not be able to teleport after using this waypoint",
./src/ui/properties/WayPointNodeEditor.js:34:  "willDisableTeleport",
```

In Hubs we have `willDisableTeleporting`:
```js
./src/gltf-component-mappings.js:116:    willDisableTeleporting: false,
./src/systems/waypoint-system.js:390:    willDisableTeleporting: { default: false },
./src/systems/character-controller-system.js:177:          (!isMobile || this.activeWaypoint.waypointComponentData.willDisableTeleporting);
./src/systems/character-controller-system.js:178:        this.isTeleportingDisabled = this.activeWaypoint.waypointComponentData.willDisableTeleporting;
./src/react-components/object-info-dialog.js:181:        willDisableTeleporting: false,
```