### PR TITLE
Support multiple animations on a single model

### DIFF
--- a/src/editor/MeshCombinationGroup.js
+++ b/src/editor/MeshCombinationGroup.js
@@ -126,7 +126,7 @@ export default class MeshCombinationGroup {
     }
 
     await asyncTraverse(rootObject, async object => {
-      if (isStatic(object) && object.isMesh) {
+      if (isStatic(object) && object.isMesh && object._combine !== false) {
         let added = false;
 
         for (const group of meshCombinationGroups) {

--- a/src/editor/nodes/EditorNodeMixin.js
+++ b/src/editor/nodes/EditorNodeMixin.js
@@ -208,34 +208,72 @@ export default function EditorNodeMixin(Object3DClass) {
       }
     }
 
-    addGLTFComponent(name, props) {
-      if (!this.userData.gltfExtensions) {
-        this.userData.gltfExtensions = {};
-      }
+    /**
+     * Adds a GLTF component
+     * @param {String} name The component name to be replaced
+     * @param {Object} props The component properties to be set
+     * @param {boolean} params Parameters object
+     * @param {{THREE.Object3D} params.node The target Object3D element
+     * @param {boolean} params.replace Wether or not the component should be replaced or just added if it does not exist
+     * @param {boolean} params.recursive Call this method recursively on all the Object3D children
+     */
+    addGLTFComponent(name, props, params = {}) {
+      params.node = params.node || this;
+      params.replace = params.replace || false;
+      params.recursive = params.recursive || false;
 
-      if (!this.userData.gltfExtensions.MOZ_hubs_components) {
-        this.userData.gltfExtensions.MOZ_hubs_components = {};
+      let update = false;
+      if (params.replace) {
+        if (
+          params.node.userData.gltfExtensions &&
+          params.node.userData.gltfExtensions.MOZ_hubs_components &&
+          params.node.userData.gltfExtensions.MOZ_hubs_components[name]
+        ) {
+          update = true;
+        }
+      } else {
+        if (!params.node.userData.gltfExtensions) {
+          params.node.userData.gltfExtensions = {};
+        }
+
+        if (!params.node.userData.gltfExtensions.MOZ_hubs_components) {
+          params.node.userData.gltfExtensions.MOZ_hubs_components = {};
+        }
+
+        update = true;
       }
 
       if (props !== undefined && typeof props !== "object") {
         throw new Error("glTF component props must be an object or undefined");
       }
 
-      const componentProps = {};
+      if (update) {
+        const componentProps = {};
 
-      for (const key in props) {
-        if (!Object.prototype.hasOwnProperty.call(props, key)) continue;
+        for (const key in props) {
+          if (!Object.prototype.hasOwnProperty.call(props, key)) continue;
 
-        const value = props[key];
+          const value = props[key];
 
-        if (value instanceof Color) {
-          componentProps[key] = serializeColor(value);
-        } else {
-          componentProps[key] = value;
+          if (value instanceof Color) {
+            componentProps[key] = serializeColor(value);
+          } else {
+            componentProps[key] = value;
+          }
         }
+
+        params.node.userData.gltfExtensions.MOZ_hubs_components[name] = componentProps;
       }
 
-      this.userData.gltfExtensions.MOZ_hubs_components[name] = componentProps;
+      if (params.recursive) {
+        params.node.children.forEach(child => {
+          this.addGLTFComponent(name, props, {
+            node: child,
+            replace: params.replace,
+            recursive: params.recursive
+          });
+        });
+      }
     }
 
     replaceObject(replacementObject) {

--- a/src/editor/nodes/EditorNodeMixin.js
+++ b/src/editor/nodes/EditorNodeMixin.js
@@ -214,66 +214,35 @@ export default function EditorNodeMixin(Object3DClass) {
      * @param {Object} props The component properties to be set
      * @param {boolean} params Parameters object
      * @param {{THREE.Object3D} params.node The target Object3D element
-     * @param {boolean} params.replace Wether or not the component should be replaced or just added if it does not exist
-     * @param {boolean} params.recursive Call this method recursively on all the Object3D children
      */
-    addGLTFComponent(name, props, params = {}) {
-      params.node = params.node || this;
-      params.replace = params.replace || false;
-      params.recursive = params.recursive || false;
+    addGLTFComponent(name, props) {
+      if (!this.userData.gltfExtensions) {
+        this.userData.gltfExtensions = {};
+      }
 
-      let update = false;
-      if (params.replace) {
-        if (
-          params.node.userData.gltfExtensions &&
-          params.node.userData.gltfExtensions.MOZ_hubs_components &&
-          params.node.userData.gltfExtensions.MOZ_hubs_components[name]
-        ) {
-          update = true;
-        }
-      } else {
-        if (!params.node.userData.gltfExtensions) {
-          params.node.userData.gltfExtensions = {};
-        }
-
-        if (!params.node.userData.gltfExtensions.MOZ_hubs_components) {
-          params.node.userData.gltfExtensions.MOZ_hubs_components = {};
-        }
-
-        update = true;
+      if (!this.userData.gltfExtensions.MOZ_hubs_components) {
+        this.userData.gltfExtensions.MOZ_hubs_components = {};
       }
 
       if (props !== undefined && typeof props !== "object") {
         throw new Error("glTF component props must be an object or undefined");
       }
 
-      if (update) {
-        const componentProps = {};
+      const componentProps = {};
 
-        for (const key in props) {
-          if (!Object.prototype.hasOwnProperty.call(props, key)) continue;
+      for (const key in props) {
+        if (!Object.prototype.hasOwnProperty.call(props, key)) continue;
 
-          const value = props[key];
+        const value = props[key];
 
-          if (value instanceof Color) {
-            componentProps[key] = serializeColor(value);
-          } else {
-            componentProps[key] = value;
-          }
+        if (value instanceof Color) {
+          componentProps[key] = serializeColor(value);
+        } else {
+          componentProps[key] = value;
         }
-
-        params.node.userData.gltfExtensions.MOZ_hubs_components[name] = componentProps;
       }
 
-      if (params.recursive) {
-        params.node.children.forEach(child => {
-          this.addGLTFComponent(name, props, {
-            node: child,
-            replace: params.replace,
-            recursive: params.recursive
-          });
-        });
-      }
+      this.userData.gltfExtensions.MOZ_hubs_components[name] = componentProps;
     }
 
     replaceObject(replacementObject) {

--- a/src/editor/nodes/KitPieceNode.js
+++ b/src/editor/nodes/KitPieceNode.js
@@ -28,6 +28,7 @@ export default class KitPieceNode extends EditorNodeMixin(Model) {
 
         node.collidable = !!json.components.find(c => c.name === "collidable");
         node.walkable = !!json.components.find(c => c.name === "walkable");
+        node.combine = !!json.components.find(c => c.name === "combine");
 
         const loopAnimationComponent = json.components.find(c => c.name === "loop-animation");
 
@@ -65,6 +66,7 @@ export default class KitPieceNode extends EditorNodeMixin(Model) {
     this._canonicalUrl = "";
     this.collidable = true;
     this.walkable = true;
+    this.combine = true;
     this._kitId = null;
     this._pieceId = null;
     this.subPieces = [];
@@ -439,6 +441,10 @@ export default class KitPieceNode extends EditorNodeMixin(Model) {
       components.walkable = {};
     }
 
+    if (this.combine) {
+      components.combine = {};
+    }
+
     return super.serialize(components);
   }
 
@@ -451,6 +457,7 @@ export default class KitPieceNode extends EditorNodeMixin(Model) {
     this._pieceId = source._pieceId;
     this.collidable = source.collidable;
     this.walkable = source.walkable;
+    this.combine = source.combine;
 
     // TODO update the sub-piece copy method
     if (this.model) {

--- a/src/editor/nodes/KitPieceNode.js
+++ b/src/editor/nodes/KitPieceNode.js
@@ -33,12 +33,17 @@ export default class KitPieceNode extends EditorNodeMixin(Model) {
 
         if (loopAnimationComponent && loopAnimationComponent.props) {
           const { clip, activeClipIndex } = loopAnimationComponent.props;
+          const { activeClipIndices } = loopAnimationComponent.props;
 
-          if (activeClipIndex !== undefined) {
-            node.activeClipIndex = loopAnimationComponent.props.activeClipIndex;
-          } else if (clip !== undefined && node.model && node.model.animations) {
-            // DEPRECATED: Old loop-animation component stored the clip name rather than the clip index
-            node.activeClipIndex = node.model.animations.findIndex(animation => animation.name === clip);
+          if (activeClipIndices !== undefined) {
+            node.activeClipIndices = activeClipIndices;
+          } else {
+            if (activeClipIndex !== undefined) {
+              node.activeClipIndices = activeClipIndex;
+            } else if (clip !== undefined && node.model && node.model.animations) {
+              // DEPRECATED: Old loop-animation component stored the clip name rather than the clip index
+              node.activeClipIndices = [node.model.animations.findIndex(animation => animation.name === clip)];
+            }
           }
         }
 
@@ -422,11 +427,9 @@ export default class KitPieceNode extends EditorNodeMixin(Model) {
       }
     };
 
-    if (this.activeClipIndex !== -1) {
-      components["loop-animation"] = {
-        activeClipIndex: this.activeClipIndex
-      };
-    }
+    components["loop-animation"] = {
+      activeClipIndices: this.activeClipIndices
+    };
 
     if (this.collidable) {
       components.collidable = {};
@@ -495,27 +498,23 @@ export default class KitPieceNode extends EditorNodeMixin(Model) {
     return this;
   }
 
-  prepareForExport(ctx) {
+  prepareForExport() {
     super.prepareForExport();
     this.addGLTFComponent("shadow", {
       cast: this.castShadow,
       receive: this.receiveShadow
     });
 
-    // TODO: Support exporting more than one active clip.
-    if (this.activeClip) {
-      const activeClipIndex = ctx.animations.indexOf(this.activeClip);
-
-      if (activeClipIndex === -1) {
-        throw new Error(
-          `Error exporting model "${this.name}" with url "${this._canonicalUrl}". Animation could not be found.`
-        );
-      } else {
-        this.addGLTFComponent("loop-animation", {
-          activeClipIndex: activeClipIndex
-        });
+    this.addGLTFComponent(
+      "loop-animation",
+      {
+        activeClipIndices: this.getActiveClipIndices()
+      },
+      {
+        replace: true,
+        recursive: true
       }
-    }
+    );
 
     if (this.model) {
       // Clear kit-piece extension data

--- a/src/editor/nodes/ModelNode.js
+++ b/src/editor/nodes/ModelNode.js
@@ -48,6 +48,7 @@ export default class ModelNode extends EditorNodeMixin(Model) {
 
         node.collidable = !!json.components.find(c => c.name === "collidable");
         node.walkable = !!json.components.find(c => c.name === "walkable");
+        node.combine = !!json.components.find(c => c.name === "combine");
 
         const loopAnimationComponent = json.components.find(c => c.name === "loop-animation");
 
@@ -85,6 +86,7 @@ export default class ModelNode extends EditorNodeMixin(Model) {
     this._canonicalUrl = "";
     this.collidable = true;
     this.walkable = true;
+    this.combine = true;
     this.initialScale = 1;
     this.boundingBox = new Box3();
     this.boundingSphere = new Sphere();
@@ -332,6 +334,10 @@ export default class ModelNode extends EditorNodeMixin(Model) {
       components.walkable = {};
     }
 
+    if (this.combine) {
+      components.combine = {};
+    }
+
     return super.serialize(components);
   }
 
@@ -351,6 +357,7 @@ export default class ModelNode extends EditorNodeMixin(Model) {
     this.attribution = source.attribution;
     this.collidable = source.collidable;
     this.walkable = source.walkable;
+    this.combine = source.combine;
     return this;
   }
 

--- a/src/editor/nodes/SceneNode.js
+++ b/src/editor/nodes/SceneNode.js
@@ -138,6 +138,33 @@ function migrateV3ToV4(json) {
   return json;
 }
 
+const combineComponents = ["gltf-model", "kit-piece"];
+
+function migrateV4ToV5(json) {
+  json.version = 5;
+
+  for (const entityId in json.entities) {
+    if (!Object.prototype.hasOwnProperty.call(json.entities, entityId)) continue;
+
+    const entity = json.entities[entityId];
+
+    if (!entity.components) {
+      continue;
+    }
+
+    const hasCombineComponent = entity.components.find(c => combineComponents.indexOf(c.name) !== -1);
+
+    if (hasCombineComponent) {
+      entity.components.push({
+        name: "combine",
+        props: {}
+      });
+    }
+  }
+
+  return json;
+}
+
 export const FogType = {
   Disabled: "disabled",
   Linear: "linear",
@@ -164,6 +191,10 @@ export default class SceneNode extends EditorNodeMixin(Scene) {
 
     if (json.version === 3) {
       json = migrateV3ToV4(json);
+    }
+
+    if (json.version === 4) {
+      json = migrateV4ToV5(json);
     }
 
     const { root, metadata, entities } = json;
@@ -403,7 +434,7 @@ export default class SceneNode extends EditorNodeMixin(Scene) {
 
   serialize() {
     const sceneJson = {
-      version: 4,
+      version: 5,
       root: this.uuid,
       metadata: JSON.parse(JSON.stringify(this.metadata)),
       entities: {

--- a/src/editor/nodes/SceneNode.js
+++ b/src/editor/nodes/SceneNode.js
@@ -577,11 +577,7 @@ export default class SceneNode extends EditorNodeMixin(Scene) {
 
     this.traverse(child => {
       if (child.isNode && child.type === "Model") {
-        const activeClip = child.activeClip;
-
-        if (activeClip) {
-          animations.push(child.activeClip);
-        }
+        animations.push(...child.clips);
       }
     });
 

--- a/src/editor/objects/Model.js
+++ b/src/editor/objects/Model.js
@@ -11,6 +11,7 @@ export default class Model extends Object3D {
     this._src = null;
     this._castShadow = false;
     this._receiveShadow = false;
+    this._combine = true;
     this.activeClipIndices = [];
     this.animationMixer = null;
     this.currentActions = [];
@@ -53,6 +54,7 @@ export default class Model extends Object3D {
 
     this.castShadow = this._castShadow;
     this.receiveShadow = this._receiveShadow;
+    this.combine = this._combine;
 
     return this;
   }
@@ -205,6 +207,20 @@ export default class Model extends Object3D {
             material.needsUpdate = true;
           }
         }
+      });
+    }
+  }
+
+  get combine() {
+    return this._combine;
+  }
+
+  set combine(value) {
+    this._combine = value;
+
+    if (this.model) {
+      this.model.traverse(child => {
+        child._combine = value;
       });
     }
   }

--- a/src/ui/inputs/SelectInput.js
+++ b/src/ui/inputs/SelectInput.js
@@ -55,6 +55,18 @@ const staticStyle = {
   singleValue: (base, { isDisabled }) => ({
     ...base,
     color: isDisabled ? "grey" : "white"
+  }),
+  multiValue: (base, { isDisabled }) => ({
+    ...base,
+    backgroundColor: isDisabled ? "grey" : "#006EFF"
+  }),
+  multiValueLabel: (base, { isDisabled }) => ({
+    ...base,
+    color: isDisabled ? "black" : "white"
+  }),
+  multiValueRemove: (base, { isFocused }) => ({
+    ...base,
+    color: isFocused ? "grey" : "white"
   })
 };
 
@@ -69,16 +81,17 @@ export default function SelectInput({
   creatable,
   ...rest
 }) {
-  const selectedOption =
-    options.find(o => {
-      if (o === null) {
-        return o;
-      } else if (o.value && o.value.equals) {
-        return o.value.equals(value);
-      } else {
-        return o.value === value;
-      }
-    }) || null;
+  const selectedOption = Array.isArray(value)
+    ? value
+    : options.find(o => {
+        if (o === null) {
+          return o;
+        } else if (o.value && o.value.equals) {
+          return o.value.equals(value);
+        } else {
+          return o.value === value;
+        }
+      }) || null;
 
   const dynamicStyle = {
     ...staticStyle,
@@ -99,7 +112,17 @@ export default function SelectInput({
       components={{ IndicatorSeparator: () => null }}
       placeholder={placeholder}
       options={options}
-      onChange={option => onChange(option && option.value, option)}
+      onChange={option => {
+        if (Array.isArray(option)) {
+          onChange(
+            option.filter(item => {
+              return item.value >= 0;
+            })
+          );
+        } else {
+          onChange(option && option.value, option);
+        }
+      }}
       isDisabled={disabled}
     />
   );

--- a/src/ui/properties/KitPieceNodeEditor.js
+++ b/src/ui/properties/KitPieceNodeEditor.js
@@ -122,6 +122,10 @@ export default class KitPieceNodeEditor extends Component {
     this.props.editor.setPropertySelected("receiveShadow", receiveShadow);
   };
 
+  onChangeCombine = combine => {
+    this.props.editor.setPropertySelected("combine", combine);
+  };
+
   isAnimationPropertyDisabled() {
     const { multiEdit, editor, node } = this.props;
 
@@ -188,6 +192,9 @@ export default class KitPieceNodeEditor extends Component {
         </InputGroup>
         <InputGroup name="Receive Shadow">
           <BooleanInput value={node.receiveShadow} onChange={this.onChangeReceiveShadow} />
+        </InputGroup>
+        <InputGroup name="Combine">
+          <BooleanInput value={node.combine} onChange={this.onChangeCombine} />
         </InputGroup>
       </NodeEditor>
     );

--- a/src/ui/properties/ModelNodeEditor.js
+++ b/src/ui/properties/ModelNodeEditor.js
@@ -23,8 +23,8 @@ export default class ModelNodeEditor extends Component {
     this.props.editor.setPropertiesSelected({ ...initialProps, src });
   };
 
-  onChangeAnimation = activeClipIndex => {
-    this.props.editor.setPropertySelected("activeClipIndex", activeClipIndex);
+  onChangeAnimation = activeClipIndices => {
+    this.props.editor.setPropertySelected("activeClipIndices", activeClipIndices || []);
   };
 
   onChangeCollidable = collidable => {
@@ -65,8 +65,11 @@ export default class ModelNodeEditor extends Component {
           <SelectInput
             disabled={this.isAnimationPropertyDisabled()}
             options={node.getClipOptions()}
-            value={node.activeClipIndex}
+            value={node.activeClipIndices}
             onChange={this.onChangeAnimation}
+            className="basic-multi-select"
+            classNamePrefix="select"
+            isMulti
           />
         </InputGroup>
         <InputGroup name="Collidable">

--- a/src/ui/properties/ModelNodeEditor.js
+++ b/src/ui/properties/ModelNodeEditor.js
@@ -43,6 +43,10 @@ export default class ModelNodeEditor extends Component {
     this.props.editor.setPropertySelected("receiveShadow", receiveShadow);
   };
 
+  onChangeCombine = combine => {
+    this.props.editor.setPropertySelected("combine", combine);
+  };
+
   isAnimationPropertyDisabled() {
     const { multiEdit, editor, node } = this.props;
 
@@ -83,6 +87,9 @@ export default class ModelNodeEditor extends Component {
         </InputGroup>
         <InputGroup name="Receive Shadow">
           <BooleanInput value={node.receiveShadow} onChange={this.onChangeReceiveShadow} />
+        </InputGroup>
+        <InputGroup name="Combine">
+          <BooleanInput value={node.combine} onChange={this.onChangeCombine} />
         </InputGroup>
         {node.model && <GLTFInfo node={node} />}
       </NodeEditor>


### PR DESCRIPTION
Spoke now supports multiple animations per model. After importing a model from Sketchfab or your favorite 3D tool, you can now select multiple animations to loop in the Spoke property panel.

There is also a new checkbox to ignore mesh combination for a specific model. This can be useful when you want to add dynamic behavior to an object in your custom Hubs Cloud client.

![image](https://user-images.githubusercontent.com/1753624/95106810-d970db80-06ed-11eb-9c34-928714f51513.png)



Fixes #924 Support multiple animations on a single model

Depends on https://github.com/mozilla/hubs/pull/3061