### PR TITLE
Add support for manual attribution update

### DIFF
--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -287,11 +287,12 @@ export default class Project extends EventEmitter {
     if (resolveMediaCache.has(cacheKey)) return resolveMediaCache.get(cacheKey);
 
     const request = (async () => {
-      let contentType, canonicalUrl, accessibleUrl;
+      let contentType, canonicalUrl, accessibleUrl, meta;
 
       try {
         const result = await this.resolveUrl(absoluteUrl);
         canonicalUrl = result.origin;
+        meta = result.meta;
         accessibleUrl = proxiedUrlFor(canonicalUrl, index);
 
         contentType =
@@ -315,7 +316,7 @@ export default class Project extends EventEmitter {
         throw new RethrownError(`Error loading Sketchfab model "${accessibleUrl}"`, error);
       }
 
-      return { canonicalUrl, accessibleUrl, contentType };
+      return { canonicalUrl, accessibleUrl, contentType, meta };
     })();
 
     resolveMediaCache.set(cacheKey, request);

--- a/src/api/PublishDialog.js
+++ b/src/api/PublishDialog.js
@@ -107,7 +107,18 @@ export default class PublishDialog extends Component {
         {contentAttributions && (
           <FormField>
             <label>Model Attribution:</label>
-            <p>{contentAttributions.map(a => `${a.name} by ${a.author}\n`)}</p>
+            <ul>
+              {contentAttributions.map(
+                (a, i) =>
+                  a.author &&
+                  a.title && (
+                    <li key={i}>
+                      <b>{`${a.title}`}</b>
+                      {(a.author && ` (by ${a.author})`) || ` (by Unknown)`}
+                    </li>
+                  )
+              )}
+            </ul>
           </FormField>
         )}
       </PreviewDialog>

--- a/src/editor/nodes/EditorNodeMixin.js
+++ b/src/editor/nodes/EditorNodeMixin.js
@@ -387,5 +387,41 @@ export default function EditorNodeMixin(Object3DClass) {
     getRuntimeResourcesForStats() {
       // return { textures: [], materials: [], meshes: [], lights: [] };
     }
+
+    // Returns the node's attribution information by default just the name
+    // This should be overriding by nodes that can provide a more specific info (ie. models based on GLTF)
+    getAttribution() {
+      return {
+        title: this.name.replace(/\.[^/.]+$/, "")
+      };
+    }
+
+    // Updates attribution information. The meta information from the API is consider the most authoritative source
+    // That info then would be updated with node's source information if exists.
+    updateAttribution() {
+      const attribution = this.getAttribution();
+      this.attribution = this.attribution || {};
+      if (this.meta) {
+        Object.assign(
+          this.attribution,
+          this.meta.author ? { author: this.meta.author } : null,
+          this.meta.name ? { title: this.meta.name } : this.name ? { title: this.name.replace(/\.[^/.]+$/, "") } : null,
+          this.meta.author && this.meta.name && this._canonicalUrl ? { url: this._canonicalUrl } : null
+        );
+      }
+      // Replace the attribute keys only if they don't exist otherwise
+      // we give preference to the info coming from the API source over the GLTF asset
+      Object.keys(this.attribution).forEach(key => {
+        if (!this.attribution[key] || this.attribution[key] == null) {
+          this.attribution[key] = attribution[key];
+        }
+      });
+      // If the GLTF attribution info has keys that are missing form the API source, we add them
+      for (const key in attribution) {
+        if (!Object.prototype.hasOwnProperty.call(this.attribution, key)) {
+          this.attribution[key] = attribution[key];
+        }
+      }
+    }
   };
 }

--- a/src/editor/nodes/EditorNodeMixin.js
+++ b/src/editor/nodes/EditorNodeMixin.js
@@ -404,7 +404,7 @@ export default function EditorNodeMixin(Object3DClass) {
       if (this.meta) {
         Object.assign(
           this.attribution,
-          this.meta.author ? { author: this.meta.author } : null,
+          this.meta.author ? { author: this.meta.author ? this.meta.author.replace(/ \(http.+\)/, "") : "" } : null,
           this.meta.name ? { title: this.meta.name } : this.name ? { title: this.name.replace(/\.[^/.]+$/, "") } : null,
           this.meta.author && this.meta.name && this._canonicalUrl ? { url: this._canonicalUrl } : null
         );
@@ -419,7 +419,11 @@ export default function EditorNodeMixin(Object3DClass) {
       // If the GLTF attribution info has keys that are missing form the API source, we add them
       for (const key in attribution) {
         if (!Object.prototype.hasOwnProperty.call(this.attribution, key)) {
-          this.attribution[key] = attribution[key];
+          if (key === "author") {
+            this.attribution[key] = attribution[key] ? attribution[key].replace(/ \(http.+\)/, "") : "";
+          } else {
+            this.attribution[key] = attribution[key];
+          }
         }
       }
     }

--- a/src/editor/nodes/ImageNode.js
+++ b/src/editor/nodes/ImageNode.js
@@ -70,7 +70,12 @@ export default class ImageNode extends EditorNodeMixin(Image) {
     this.showLoadingCube();
 
     try {
-      const { accessibleUrl } = await this.editor.api.resolveMedia(src);
+      const { accessibleUrl, meta } = await this.editor.api.resolveMedia(src);
+
+      this.meta = meta;
+
+      this.updateAttribution();
+
       await super.load(accessibleUrl);
       this.issues = getObjectPerfIssues(this._mesh, false);
 

--- a/src/editor/nodes/SceneNode.js
+++ b/src/editor/nodes/SceneNode.js
@@ -631,7 +631,7 @@ export default class SceneNode extends EditorNodeMixin(Scene) {
     const seenAttributions = new Set();
 
     this.traverse(obj => {
-      if (!(obj.isNode && obj.type === "Model")) return;
+      if (!(obj.isNode && obj.attribution)) return;
       const attribution = obj.attribution;
 
       if (!attribution) return;

--- a/src/editor/nodes/SceneNode.js
+++ b/src/editor/nodes/SceneNode.js
@@ -637,7 +637,7 @@ export default class SceneNode extends EditorNodeMixin(Scene) {
       if (!attribution) return;
 
       if (attribution) {
-        const attributionKey = attribution.url || `${attribution.name}_${attribution.author}`;
+        const attributionKey = attribution.url || `${attribution.title}_${attribution.author}`;
         if (seenAttributions.has(attributionKey)) return;
         seenAttributions.add(attributionKey);
         contentAttributions.push(attribution);

--- a/src/editor/nodes/SpawnerNode.js
+++ b/src/editor/nodes/SpawnerNode.js
@@ -71,6 +71,8 @@ export default class SpawnerNode extends EditorNodeMixin(Model) {
     this.stats = stats;
     this.gltfJson = json;
 
+    this.updateAttribution();
+
     return cloneObject3D(scene);
   }
 
@@ -98,7 +100,9 @@ export default class SpawnerNode extends EditorNodeMixin(Model) {
     this.showLoadingCube();
 
     try {
-      const { accessibleUrl, files } = await this.editor.api.resolveMedia(src);
+      const { accessibleUrl, files, meta } = await this.editor.api.resolveMedia(src);
+
+      this.meta = meta;
 
       if (this.model) {
         this.editor.renderer.removeBatchedObject(this.model);

--- a/src/editor/nodes/VideoNode.js
+++ b/src/editor/nodes/VideoNode.js
@@ -102,7 +102,11 @@ export default class VideoNode extends EditorNodeMixin(Video) {
     }
 
     try {
-      const { accessibleUrl, contentType } = await this.editor.api.resolveMedia(src);
+      const { accessibleUrl, contentType, meta } = await this.editor.api.resolveMedia(src);
+
+      this.meta = meta;
+
+      this.updateAttribution();
 
       const isHls = isHLS(src, contentType);
 

--- a/src/editor/objects/AudioSource.js
+++ b/src/editor/objects/AudioSource.js
@@ -231,8 +231,12 @@ export default class AudioSource extends Object3D {
 
   async load(src) {
     await this.loadMedia(src);
-    this.audioSource = this.audioListener.context.createMediaElementSource(this.el);
-    this.audio.setNodeSource(this.audioSource);
+
+    if (this.audioSource === undefined) {
+      this.audioSource = this.audioListener.context.createMediaElementSource(this.el);
+      this.audio.setNodeSource(this.audioSource);
+    }
+
     return this;
   }
 

--- a/src/editor/objects/Model.js
+++ b/src/editor/objects/Model.js
@@ -15,6 +15,7 @@ export default class Model extends Object3D {
     this.activeClipItems = [];
     this.animationMixer = null;
     this.currentActions = [];
+    this.meta = null;
   }
 
   get src() {

--- a/src/editor/objects/Video.js
+++ b/src/editor/objects/Video.js
@@ -133,8 +133,10 @@ export default class Video extends AudioSource {
 
     this.onResize();
 
-    this.audioSource = this.audioListener.context.createMediaElementSource(this.el);
-    this.audio.setNodeSource(this.audioSource);
+    if (this.audioSource === undefined) {
+      this.audioSource = this.audioListener.context.createMediaElementSource(this.el);
+      this.audio.setNodeSource(this.audioSource);
+    }
 
     if (this._texture.format === RGBAFormat) {
       this._mesh.material.transparent = true;

--- a/src/ui/properties/AttributionNodeEditor.js
+++ b/src/ui/properties/AttributionNodeEditor.js
@@ -1,0 +1,52 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import InputGroup from "../inputs/InputGroup";
+import ModelInput from "../inputs/ModelInput";
+import Collapsible from "../inputs/Collapsible";
+
+export default class NodeEditor extends Component {
+  static propTypes = {
+    name: PropTypes.string,
+    description: PropTypes.string,
+    node: PropTypes.object,
+    editor: PropTypes.object,
+    children: PropTypes.node,
+    disableTransform: PropTypes.bool
+  };
+
+  static defaultProps = {
+    disableTransform: false
+  };
+
+  onChangeAttribution = (attribution, key, value) => {
+    attribution[key] = value;
+    this.props.editor.setPropertySelected("attribution", attribution);
+  };
+
+  render() {
+    const { name, node } = this.props;
+
+    return (
+      <Collapsible label={name}>
+        <InputGroup name="Title">
+          <ModelInput
+            value={(node.attribution && node.attribution.title) || ""}
+            onChange={title => this.onChangeAttribution(node.attribution, "title", title)}
+          />
+        </InputGroup>
+        <InputGroup name="Author">
+          <ModelInput
+            value={(node.attribution && node.attribution.author) || ""}
+            onChange={author => this.onChangeAttribution(node.attribution, "author", author)}
+          />
+        </InputGroup>
+        <InputGroup name="Url">
+          <ModelInput
+            value={(node.attribution && node.attribution.url) || ""}
+            onChange={url => this.onChangeAttribution(node.attribution, "url", url)}
+          />
+        </InputGroup>
+      </Collapsible>
+    );
+  }
+}

--- a/src/ui/properties/ImageNodeEditor.js
+++ b/src/ui/properties/ImageNodeEditor.js
@@ -9,6 +9,7 @@ import { ImageProjection, ImageAlphaMode } from "../../editor/objects/Image";
 import ImageInput from "../inputs/ImageInput";
 import { Image } from "styled-icons/fa-solid/Image";
 import useSetPropertySelected from "./useSetPropertySelected";
+import AttributionNodeEditor from "./AttributionNodeEditor";
 
 const mapValue = v => ({ label: v, value: v });
 const imageProjectionOptions = Object.values(ImageProjection).map(mapValue);
@@ -56,6 +57,7 @@ export default function ImageNodeEditor(props) {
       <InputGroup name="Projection">
         <SelectInput options={imageProjectionOptions} value={node.projection} onChange={onChangeProjection} />
       </InputGroup>
+      <AttributionNodeEditor name="Attribution" {...props} />
     </NodeEditor>
   );
 }

--- a/src/ui/properties/ModelNodeEditor.js
+++ b/src/ui/properties/ModelNodeEditor.js
@@ -7,6 +7,7 @@ import BooleanInput from "../inputs/BooleanInput";
 import ModelInput from "../inputs/ModelInput";
 import { Cube } from "styled-icons/fa-solid/Cube";
 import { GLTFInfo } from "../inputs/GLTFInfo";
+import AttributionNodeEditor from "./AttributionNodeEditor";
 
 export default class ModelNodeEditor extends Component {
   static propTypes = {
@@ -92,6 +93,7 @@ export default class ModelNodeEditor extends Component {
           <BooleanInput value={node.combine} onChange={this.onChangeCombine} />
         </InputGroup>
         {node.model && <GLTFInfo node={node} />}
+        <AttributionNodeEditor name="Attribution" {...this.props} />
       </NodeEditor>
     );
   }

--- a/src/ui/properties/SpawnerNodeEditor.js
+++ b/src/ui/properties/SpawnerNodeEditor.js
@@ -6,6 +6,7 @@ import ModelInput from "../inputs/ModelInput";
 import BooleanInput from "../inputs/BooleanInput";
 import { Magic } from "styled-icons/fa-solid/Magic";
 import { GLTFInfo } from "../inputs/GLTFInfo";
+import AttributionNodeEditor from "./AttributionNodeEditor";
 
 export default class SpawnerNodeEditor extends Component {
   static propTypes = {
@@ -37,6 +38,7 @@ export default class SpawnerNodeEditor extends Component {
           <BooleanInput value={node.applyGravity} onChange={this.onChangeApplyGravity} />
         </InputGroup>
         {node.model && <GLTFInfo node={node} />}
+        <AttributionNodeEditor name="Attribution" {...this.props} />
       </NodeEditor>
     );
   }

--- a/src/ui/properties/VideoNodeEditor.js
+++ b/src/ui/properties/VideoNodeEditor.js
@@ -8,6 +8,7 @@ import VideoInput from "../inputs/VideoInput";
 import { Video } from "styled-icons/fa-solid/Video";
 import AudioSourceProperties from "./AudioSourceProperties";
 import useSetPropertySelected from "./useSetPropertySelected";
+import AttributionNodeEditor from "./AttributionNodeEditor";
 
 const videoProjectionOptions = Object.values(VideoProjection).map(v => ({ label: v, value: v }));
 
@@ -25,6 +26,7 @@ export default function VideoNodeEditor(props) {
         <SelectInput options={videoProjectionOptions} value={node.projection} onChange={onChangeProjection} />
       </InputGroup>
       <AudioSourceProperties {...props} />
+      <AttributionNodeEditor name="Attribution" {...props} />
     </NodeEditor>
   );
 }


### PR DESCRIPTION
closes #414 This PR adds support to show/edit attribution information in scene assets, specifically Model, Video, Image and Spawners. What this does right now:
- Update nodes attributions when media is resolved so in all cases where new media is added or updated (asset dropoff, node url update or from media gallery)
- All assets attribution is initially set based in the meta information returned by `resolveMedia` and then updated with the asset file info in case it's available (i.e. GLTF embedded asset info)
- Displays the attribution information in the Publishing dialog, one line per attribution element

It also fixes an issue with adding new source to audio/video nodes that threw an exception in Chrome an the updated element didn't work:
```
Cause:
    Failed to execute 'createMediaElementSource' on 'AudioContext': HTMLMediaElement already connected previously to a different MediaElementSourceNode.
```

We still need to solve the case where we can add per node GLTF attribution information based on https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_xmp/README.md Right now none of the sources support it but would be useful for exporting GLTF Spoke scenes while keeping all the attribution data. See https://github.com/mozilla/Spoke/issues/1044