### PR TITLE
Add support for creating scenes directly from GLBs

### DIFF
--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -1005,13 +1005,7 @@ export default class Project extends EventEmitter {
       screenshot_file_token: screenshotToken,
       model_file_id: glbId,
       model_file_token: glbToken,
-      allow_remixing: params.allowRemixing,
-      allow_promotion: params.allowPromotion,
-      name: params.name,
-      attributions: {
-        creator: params.creatorAttribution,
-        content: []
-      }
+      ...params
     };
 
     const body = JSON.stringify({ scene: sceneParams });

--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -228,6 +228,25 @@ export default class Project extends EventEmitter {
     return json;
   }
 
+  async getProjectlessScenes() {
+    const token = this.getToken();
+
+    const headers = {
+      "content-type": "application/json",
+      authorization: `Bearer ${token}`
+    };
+
+    const response = await this.fetch(`https://${RETICULUM_SERVER}/api/v1/scenes/projectless`, { headers });
+
+    const json = await response.json();
+
+    if (!Array.isArray(json.scenes)) {
+      throw new Error(`Error fetching scenes: ${json.error || "Unknown error."}`);
+    }
+
+    return json.scenes;
+  }
+
   async resolveUrl(url, index) {
     if (!shouldCorsProxy(url)) {
       return { origin: url };
@@ -981,22 +1000,6 @@ export default class Project extends EventEmitter {
       authorization: `Bearer ${this.getToken()}`
     };
 
-    // HACK: Create a dummy project to add this to project listings
-    let project_id;
-    if (!sceneId) {
-      const body = JSON.stringify({
-        project: { name: "GLB Only Project" }
-      });
-      const resp = await this.fetch(`https://${RETICULUM_SERVER}/api/v1/projects`, {
-        method: "POST",
-        headers,
-        body,
-        signal
-      });
-      const project = await resp.json();
-      project_id = project.project_id;
-    }
-
     const sceneParams = {
       screenshot_file_id: screenshotId,
       screenshot_file_token: screenshotToken,
@@ -1005,7 +1008,6 @@ export default class Project extends EventEmitter {
       allow_remixing: params.allowRemixing,
       allow_promotion: params.allowPromotion,
       name: params.name,
-      project_id,
       attributions: {
         creator: params.creatorAttribution,
         content: []

--- a/src/ui/App.js
+++ b/src/ui/App.js
@@ -20,6 +20,7 @@ import LoginPage from "./auth/LoginPage";
 import LogoutPage from "./auth/LogoutPage";
 import ProjectsPage from "./projects/ProjectsPage";
 import CreateProjectPage from "./projects/CreateProjectPage";
+import CreateScenePage from "./projects/CreateScenePage";
 
 import { ThemeProvider } from "styled-components";
 
@@ -82,6 +83,7 @@ export default class App extends Component {
                   <Route path="/projects" exact component={ProjectsPage} />
                   <Route path="/projects/:projectId" component={EditorContainer} />
                   <Route path="/kits/package" component={PackageKitPage} />
+                  <Route path="/scenes/:sceneId" component={CreateScenePage} />
                   <Route render={() => <Error message="Page not found." />} />
                 </Switch>
               </Column>

--- a/src/ui/inputs/FileInput.js
+++ b/src/ui/inputs/FileInput.js
@@ -1,18 +1,33 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import styled from "styled-components";
+
 import { Button } from "./Button";
-import Hidden from "../layout/Hidden";
 
 let nextId = 0;
+
+export const FileInputContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+// We do this instead of actually hiding it so that form validation can still display tooltips correctly
+export const StyledInput = styled.input`
+  opacity: 0;
+  position: absolute;
+`;
 
 export default class FileInput extends Component {
   static propTypes = {
     label: PropTypes.string.isRequired,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    showSelectedFile: PropTypes.bool
   };
 
   static defaultProps = {
-    label: "Upload..."
+    label: "Upload...",
+    showSelectedFile: false
   };
 
   constructor(props) {
@@ -24,6 +39,7 @@ export default class FileInput extends Component {
   }
 
   onChange = e => {
+    this.setState({ filename: e.target.files[0].name });
     this.props.onChange(e.target.files, e);
   };
 
@@ -31,12 +47,13 @@ export default class FileInput extends Component {
     const { label, onChange, ...rest } = this.props;
 
     return (
-      <div>
+      <FileInputContainer>
         <Button as="label" htmlFor={this.state.id}>
           {label}
         </Button>
-        <Hidden as="input" {...rest} id={this.state.id} type="file" onChange={this.onChange} />
-      </div>
+        <StyledInput {...rest} id={this.state.id} type="file" onChange={this.onChange} />
+        {this.props.showSelectedFile && <span>{this.state.filename ? this.state.filename : "No File chosen"}</span>}
+      </FileInputContainer>
     );
   }
 }

--- a/src/ui/projects/CreateProjectPage.js
+++ b/src/ui/projects/CreateProjectPage.js
@@ -123,7 +123,7 @@ export default function CreateProjectPage({ history, location }) {
                 </ProjectGridHeaderRow>
                 <ProjectGridHeaderRow>
                   <Button as={Link} to="/scenes/new">
-                    Upload GLB
+                    Import From Blender
                   </Button>
                   <Button as={Link} to="/projects/new">
                     New Empty Project

--- a/src/ui/projects/CreateProjectPage.js
+++ b/src/ui/projects/CreateProjectPage.js
@@ -122,6 +122,9 @@ export default function CreateProjectPage({ history, location }) {
                   <SearchInput placeholder="Search scenes..." value={params.q} onChange={onChangeQuery} />
                 </ProjectGridHeaderRow>
                 <ProjectGridHeaderRow>
+                  <Button as={Link} to="/scenes/new">
+                    Upload GLB
+                  </Button>
                   <Button as={Link} to="/projects/new">
                     New Empty Project
                   </Button>

--- a/src/ui/projects/CreateScenePage.js
+++ b/src/ui/projects/CreateScenePage.js
@@ -1,0 +1,344 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import configs from "../../configs";
+import { withApi } from "../contexts/ApiContext";
+import NavBar from "../navigation/NavBar";
+import Footer from "../navigation/Footer";
+import styled from "styled-components";
+
+import StringInput from "../inputs/StringInput";
+import BooleanInput from "../inputs/BooleanInput";
+import FileInput from "../inputs/FileInput";
+import FormField from "../inputs/FormField";
+import { Button } from "../inputs/Button";
+import ProgressBar from "../inputs/ProgressBar";
+
+export const SceneUploadFormContainer = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: row;
+  background-color: ${props => props.theme.panel2};
+  border-radius: 3px;
+`;
+
+export const UploadSceneSection = styled.form`
+  padding-bottom: 100px;
+  display: flex;
+
+  &:first-child {
+    padding-top: 100px;
+  }
+
+  h1 {
+    font-size: 36px;
+  }
+
+  h2 {
+    font-size: 16px;
+  }
+`;
+
+export const UploadSceneContainer = styled.form`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  margin: 0 auto;
+  max-width: 800px;
+  min-width: 400px;
+  padding: 0 20px;
+`;
+
+export const SceneUploadHeader = styled.div`
+  margin-bottom: 36px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const LeftContent = styled.div`
+  display: flex;
+  width: 360px;
+  border-top-left-radius: inherit;
+  align-items: flex-start;
+  padding: 30px;
+  position: relative;
+
+  img,
+  div {
+    width: 300px;
+    height: 168px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    background-color: ${props => props.theme.panel};
+    border-radius: 6px;
+  }
+  input {
+    opacity: 0;
+    position: absolute;
+  }
+`;
+
+const RightContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: 30px 30px;
+
+  label[type="button"] {
+    display: flex;
+    margin-bottom: 0;
+    margin-right: 5px;
+  }
+`;
+
+class CreateScenePage extends Component {
+  static propTypes = {
+    api: PropTypes.object.isRequired,
+    history: PropTypes.object.isRequired,
+    match: PropTypes.object
+  };
+
+  constructor(props) {
+    super(props);
+
+    const isAuthenticated = this.props.api.isAuthenticated();
+
+    this.state = {
+      isAuthenticated,
+      isUploading: false,
+      isLoading: true,
+
+      sceneId: null,
+
+      error: null,
+
+      name: "",
+      creatorAttribution: "",
+      allowRemixing: false,
+      allowPromotion: false,
+      glbFile: null,
+      thumbnailFile: null,
+
+      thumbnailUrl: null,
+      sceneUrl: null
+    };
+  }
+
+  async componentDidMount() {
+    const { match } = this.props;
+    const sceneId = match.params.sceneId;
+    const isNew = sceneId === "new";
+
+    const scene = isNew ? {} : await this.props.api.getScene(sceneId);
+    this.setState({
+      name: scene.name || "",
+      creatorAttribution: scene.creatorAttribution || "",
+      allowRemixing: scene.allowRemixing,
+      allowPromotion: scene.allowPromotion,
+      thumbnailUrl: scene.screenshot_url,
+      sceneId: scene.scene_id,
+      sceneUrl: scene.url,
+      isLoading: false
+    });
+
+    console.log(sceneId, scene);
+  }
+
+  onChangeName = name => this.setState({ name });
+
+  onChangeCreatorAttribution = creatorAttribution => this.setState({ creatorAttribution });
+
+  onChangeAllowRemixing = allowRemixing => this.setState({ allowRemixing });
+
+  onChangeAllowPromotion = allowPromotion => this.setState({ allowPromotion });
+
+  onChangeGlbFile = ([glbFile]) => this.setState({ glbFile });
+
+  onChangeThumbnailFile = ([thumbnailFile]) => {
+    if (this.state.thumbnailUrl && this.state.thumbnailUrl.indexOf("data:") === 0) {
+      URL.revokeObjectURL(this.state.thumbnailUrl);
+    }
+
+    this.setState({ thumbnailFile });
+
+    // For preview
+    const reader = new FileReader();
+    reader.onload = e => {
+      this.setState({
+        thumbnailUrl: e.target.result
+      });
+    };
+    reader.readAsDataURL(thumbnailFile);
+  };
+
+  onPublish = async e => {
+    const API = this.props.api;
+
+    e.preventDefault();
+    console.log(this.state);
+
+    this.setState({ isUploading: true });
+
+    const abortController = new AbortController();
+
+    const resp = await API.publishGLBScene(
+      this.state.thumbnailFile,
+      this.state.glbFile,
+      {
+        name: this.state.name,
+        allow_remixing: this.state.allowRemixing,
+        allow_promotion: this.state.allowPromotion,
+        attributions: {
+          creator: this.state.creatorAttribution,
+          content: []
+        }
+      },
+      abortController.signal,
+      this.state.sceneId
+    );
+
+    console.log(resp);
+    const scene = resp.scenes[0];
+    this.setState({
+      isUploading: false,
+      sceneId: scene.scene_id,
+      sceneUrl: scene.url,
+      glbFile: null,
+      thumbnailFile: null
+    });
+  };
+
+  openScene = () => {
+    window.open(this.state.sceneUrl);
+  };
+
+  render() {
+    const { sceneId, sceneUrl, isLoading, isUploading } = this.state;
+
+    const isNew = !sceneId;
+
+    const { creatorAttribution, name, allowRemixing, allowPromotion } = this.state;
+
+    const maxSize = this.props.api.maxUploadSize;
+
+    const content = isLoading ? (
+      <ProgressBar />
+    ) : (
+      <>
+        <SceneUploadHeader>
+          <h1>{isNew ? "Publish Scene From GLB" : "Update GLB Scene"}</h1>
+
+          {sceneUrl && (
+            <Button disabled={isUploading} onClick={this.openScene}>
+              {configs.isMoz() ? "Open in Hubs" : "Open Scene"}
+            </Button>
+          )}
+        </SceneUploadHeader>
+        <SceneUploadFormContainer>
+          <LeftContent>
+            <label htmlFor="screenshotFile">
+              {this.state.thumbnailUrl ? (
+                <img src={this.state.thumbnailUrl} />
+              ) : (
+                <div>Click to select scene thumbnail (16:9 .png)</div>
+              )}
+            </label>
+            <input
+              id="screenshotFile"
+              type="file"
+              required={isNew}
+              accept=".png,image/png"
+              onChange={e => this.onChangeThumbnailFile(e.target.files)}
+            />
+          </LeftContent>
+
+          <RightContent>
+            <FormField>
+              <label htmlFor="sceneName">Scene Name</label>
+              <StringInput
+                id="sceneName"
+                required
+                pattern={"[A-Za-z0-9-':\"!@#$%^&*(),.?~ ]{4,64}"}
+                title="Name must be between 4 and 64 characters and cannot contain underscores"
+                value={name}
+                onChange={this.onChangeName}
+              />
+            </FormField>
+            <FormField>
+              <label htmlFor="creatorAttribution">Your Attribution (optional):</label>
+              <StringInput
+                id="creatorAttribution"
+                value={creatorAttribution}
+                onChange={this.onChangeCreatorAttribution}
+              />
+            </FormField>
+            <FormField>
+              <FormField inline>
+                <label htmlFor="allowRemixing">
+                  Allow{" "}
+                  <a
+                    href="https://github.com/mozilla/Spoke/blob/master/REMIXING.md"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Remixing
+                  </a>
+                  &nbsp;with
+                  <br />
+                  Creative Commons&nbsp;
+                  <a href="https://creativecommons.org/licenses/by/3.0/" target="_blank" rel="noopener noreferrer">
+                    CC-BY 3.0
+                  </a>
+                </label>
+                <BooleanInput id="allowRemixing" value={allowRemixing} onChange={this.onChangeAllowRemixing} />
+              </FormField>
+              <FormField inline>
+                <label htmlFor="allowPromotion">
+                  Allow {configs.isMoz() ? "Mozilla to " : ""}
+                  <a
+                    href="https://github.com/mozilla/Spoke/blob/master/PROMOTION.md"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {configs.isMoz() ? "promote" : "promotion"}
+                  </a>{" "}
+                  {configs.isMoz() ? "" : "of "}my scene
+                </label>
+                <BooleanInput id="allowPromotion" value={allowPromotion} onChange={this.onChangeAllowPromotion} />
+              </FormField>
+            </FormField>
+
+            <FormField>
+              <FileInput
+                label={isNew ? "Select scene model file (.glb)" : `Replace scene model file (max ${maxSize}mb .glb)`}
+                id="glbFile"
+                type="file"
+                required={isNew}
+                accept=".glb,model/gltf-binary"
+                showSelectedFile
+                onChange={this.onChangeGlbFile}
+              />
+            </FormField>
+            {isUploading ? <ProgressBar /> : <Button type="submit">{isNew ? "Publish" : "Update"}</Button>}
+          </RightContent>
+        </SceneUploadFormContainer>
+      </>
+    );
+
+    return (
+      <>
+        <NavBar />
+        <main>
+          <UploadSceneSection onSubmit={this.onPublish}>
+            <UploadSceneContainer>{content}</UploadSceneContainer>
+          </UploadSceneSection>
+        </main>
+        <Footer />
+      </>
+    );
+  }
+}
+
+export default withApi(CreateScenePage);

--- a/src/ui/projects/ProjectGrid.js
+++ b/src/ui/projects/ProjectGrid.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import ProjectGridItem from "./ProjectGridItem";
+import { ProjectGridItem, ProjectGridSceneItem } from "./ProjectGridItem";
 import { Row } from "../layout/Flex";
 import StringInput from "../inputs/StringInput";
 import { Link } from "react-router-dom";
@@ -63,10 +63,14 @@ const StyledProjectGrid = styled.div`
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
 `;
 
-export function ProjectGrid({ newProjectPath, newProjectLabel, projects, contextMenuId, loading }) {
+export function ProjectGrid({ newProjectPath, newProjectLabel, projects, scenes, contextMenuId, loading }) {
   return (
     <StyledProjectGrid>
       {newProjectPath && !loading && <NewProjectGridItem path={newProjectPath} label={newProjectLabel} />}
+      {scenes &&
+        scenes.map(scene => (
+          <ProjectGridSceneItem key={scene.scene_id || scene.id} scene={scene} contextMenuId={contextMenuId} />
+        ))}
       {projects.map(project => (
         <ProjectGridItem key={project.project_id || project.id} project={project} contextMenuId={contextMenuId} />
       ))}
@@ -78,6 +82,7 @@ export function ProjectGrid({ newProjectPath, newProjectLabel, projects, context
 ProjectGrid.propTypes = {
   contextMenuId: PropTypes.string,
   projects: PropTypes.arrayOf(PropTypes.object).isRequired,
+  scenes: PropTypes.arrayOf(PropTypes.object),
   newProjectPath: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   newProjectLabel: PropTypes.string,
   loading: PropTypes.bool

--- a/src/ui/projects/ProjectGridItem.js
+++ b/src/ui/projects/ProjectGridItem.js
@@ -95,7 +95,7 @@ const Col = styled.div`
   }
 `;
 
-export default class ProjectGridItem extends Component {
+export class ProjectGridItem extends Component {
   static propTypes = {
     contextMenuId: PropTypes.string,
     project: PropTypes.object.isRequired
@@ -121,21 +121,7 @@ export default class ProjectGridItem extends Component {
     const { project, contextMenuId } = this.props;
     const creatorAttribution = project.attributions && project.attributions.creator;
 
-    const isGLBOnlyProject = !project.project_url && project.scene;
-    const content = isGLBOnlyProject ? (
-      <>
-        <ThumbnailContainer>
-          {project.scene.screenshot_url && <Thumbnail src={project.scene.screenshot_url} />}
-        </ThumbnailContainer>
-        <TitleContainer>
-          <Col>
-            <h3>{project.scene.name}</h3>
-            {creatorAttribution && <p>{creatorAttribution}</p>}
-          </Col>
-          <Pill>GLB</Pill>
-        </TitleContainer>
-      </>
-    ) : (
+    const content = (
       <>
         <ThumbnailContainer>{project.thumbnail_url && <Thumbnail src={project.thumbnail_url} />}</ThumbnailContainer>
         <TitleContainer>
@@ -165,3 +151,23 @@ export default class ProjectGridItem extends Component {
     }
   }
 }
+
+export function ProjectGridSceneItem({ scene }) {
+  const creatorAttribution = scene.attributions && scene.attributions.creator;
+  return (
+    <StyledProjectGridItem to={scene.url}>
+      <ThumbnailContainer>{scene.screenshot_url && <Thumbnail src={scene.screenshot_url} />}</ThumbnailContainer>
+      <TitleContainer>
+        <Col>
+          <h3>{scene.name}</h3>
+          {creatorAttribution && <p>{creatorAttribution}</p>}
+        </Col>
+        <Pill>GLB</Pill>
+      </TitleContainer>
+    </StyledProjectGridItem>
+  );
+}
+
+ProjectGridSceneItem.propTypes = {
+  scene: PropTypes.object.isRequired
+};

--- a/src/ui/projects/ProjectGridItem.js
+++ b/src/ui/projects/ProjectGridItem.js
@@ -19,11 +19,23 @@ const StyledProjectGridItem = styled(Link)`
   background-color: ${props => props.theme.toolbar};
   text-decoration: none;
   border: 1px solid transparent;
+  position: relative;
 
   &:hover {
     color: inherit;
     border-color: ${props => props.theme.selected};
   }
+`;
+
+const Pill = styled.i`
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  padding: 3px 8px;
+  background-color: ${props => props.theme.pink};
+  color: white;
+  border-radius: 6px;
+  text-align: center;
 `;
 
 const StyledContextMenuTrigger = styled(StylableContextMenuTrigger)`
@@ -109,7 +121,21 @@ export default class ProjectGridItem extends Component {
     const { project, contextMenuId } = this.props;
     const creatorAttribution = project.attributions && project.attributions.creator;
 
-    const content = (
+    const isGLBOnlyProject = !project.project_url && project.scene;
+    const content = isGLBOnlyProject ? (
+      <>
+        <ThumbnailContainer>
+          {project.scene.screenshot_url && <Thumbnail src={project.scene.screenshot_url} />}
+        </ThumbnailContainer>
+        <TitleContainer>
+          <Col>
+            <h3>{project.scene.name}</h3>
+            {creatorAttribution && <p>{creatorAttribution}</p>}
+          </Col>
+          <Pill>GLB</Pill>
+        </TitleContainer>
+      </>
+    ) : (
       <>
         <ThumbnailContainer>{project.thumbnail_url && <Thumbnail src={project.thumbnail_url} />}</ThumbnailContainer>
         <TitleContainer>

--- a/src/ui/projects/ProjectsPage.js
+++ b/src/ui/projects/ProjectsPage.js
@@ -100,7 +100,10 @@ class ProjectsPage extends Component {
           this.setState({
             projects: projects.map(project => ({
               ...project,
-              url: `/projects/${project.project_id}`
+              url:
+                !project.project_url && project.scene
+                  ? `/scenes/${project.scene.scene_id}`
+                  : `/projects/${project.project_id}`
             })),
             loading: false
           });

--- a/src/ui/projects/ProjectsPage.js
+++ b/src/ui/projects/ProjectsPage.js
@@ -85,6 +85,7 @@ class ProjectsPage extends Component {
 
     this.state = {
       projects: [],
+      scenes: [],
       loading: isAuthenticated,
       isAuthenticated,
       error: null
@@ -94,16 +95,16 @@ class ProjectsPage extends Component {
   componentDidMount() {
     // We dont need to load projects if the user isn't logged in
     if (this.state.isAuthenticated) {
-      this.props.api
-        .getProjects()
-        .then(projects => {
+      Promise.all([this.props.api.getProjects(), this.props.api.getProjectlessScenes()])
+        .then(([projects, scenes]) => {
           this.setState({
+            scenes: scenes.map(scene => ({
+              ...scene,
+              url: `/scenes/${scene.scene_id}`
+            })),
             projects: projects.map(project => ({
               ...project,
-              url:
-                !project.project_url && project.scene
-                  ? `/scenes/${project.scene.scene_id}`
-                  : `/projects/${project.project_id}`
+              url: `/projects/${project.project_id}`
             })),
             loading: false
           });
@@ -140,7 +141,7 @@ class ProjectsPage extends Component {
   ProjectContextMenu = connectMenu(contextMenuId)(this.renderContextMenu);
 
   render() {
-    const { error, loading, projects, isAuthenticated } = this.state;
+    const { error, loading, projects, scenes, isAuthenticated } = this.state;
 
     const ProjectContextMenu = this.ProjectContextMenu;
 
@@ -190,6 +191,7 @@ class ProjectsPage extends Component {
                     <ProjectGrid
                       loading={loading}
                       projects={projects}
+                      scenes={scenes}
                       newProjectPath="/projects/templates"
                       contextMenuId={contextMenuId}
                     />


### PR DESCRIPTION
Added support for publishing scenes directly from a GLB file. They are surfaced along side other projects on the projects page, but don't actually have a project associated with them. These GLB files are expected to be complete scenes including navmeshes, spawn points, collisions, etc, likely created using the Hubs Blender Exporter.

![image](https://user-images.githubusercontent.com/130735/105948006-0c353b80-601f-11eb-862c-77c0c3f4f699.png)

Its intentionally not surfaced as a primary call to action, and the intended users for this will likely already know they want it, and what its for.  Its likely we will eventually want to move this elsewhere and/or integrate it into our other tooling more directly, but we decided to surface it in Spoke as a starting point.

Todo:
- [x] Instead of using dummy projects query for scenes directly and merge the results on the projects page
- [x] test for regressions in existing publishing flows
- [x] merge https://github.com/mozilla/reticulum/pull/462