### PR TITLE
Updated unit of Spot Light Intensity

### DIFF
--- a/src/ui/properties/SpotLightNodeEditor.js
+++ b/src/ui/properties/SpotLightNodeEditor.js
@@ -58,7 +58,7 @@ export default class SpotLightNodeEditor extends Component {
           largeStep={0.1}
           value={node.intensity}
           onChange={this.onChangeIntensity}
-          unit="°"
+          unit="cd"
         />
         <RadianNumericInputGroup
           name="Inner Cone Angle"


### PR DESCRIPTION
Changed Spot Light Intensity Unit from 'Degrees' to 'Candela'  [here.](https://github.com/mozilla/Spoke/blob/master/src/ui/properties/SpotLightNodeEditor.js#L61)

It fixes [#986](https://github.com/mozilla/Spoke/issues/986)