### PR TITLE
Check for empty attribution strings

### DIFF
--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -891,7 +891,7 @@ export default class Project extends EventEmitter {
         allow_promotion: publishParams.allowPromotion,
         name: publishParams.name,
         attributions: {
-          creator: publishParams.creatorAttribution,
+          creator: publishParams.creatorAttribution && publishParams.creatorAttribution.trim(),
           content: publishParams.contentAttributions
         }
       };

--- a/src/editor/nodes/SceneNode.js
+++ b/src/editor/nodes/SceneNode.js
@@ -656,7 +656,13 @@ export default class SceneNode extends EditorNodeMixin(Scene) {
 
       if (!attribution) return;
 
-      const attributionKey = attribution.url || `${attribution.title}_${attribution.author}`;
+      const url = attribution.url && attribution.url.trim();
+      const title = attribution.title && attribution.title.trim();
+      const author = attribution.author && attribution.author.trim();
+
+      if (!url && !title && !author) return;
+
+      const attributionKey = url || `${title}_${author}`;
       if (seenAttributions.has(attributionKey)) return;
       seenAttributions.add(attributionKey);
       contentAttributions.push(attribution);


### PR DESCRIPTION
Filter out empty attribution strings when publishing