### PR TITLE
Fix alpha mask when alpha cutoff set to 0.5

### DIFF
--- a/src/editor/gltf/GLTFExporter.js
+++ b/src/editor/gltf/GLTFExporter.js
@@ -837,14 +837,11 @@ class GLTFExporter {
     }
 
     // alphaMode
-    if (material.transparent || material.alphaTest > 0.0) {
-      // Write alphaCutoff if it's non-zero and different from the default (0.5).
-      if (material.alphaTest > 0.0 && material.alphaTest !== 0.5) {
-        gltfMaterial.alphaMode = "MASK";
-        gltfMaterial.alphaCutoff = material.alphaTest;
-      } else {
-        gltfMaterial.alphaMode = "BLEND";
-      }
+    if (material.transparent) {
+      gltfMaterial.alphaMode = "BLEND";
+    } else if (material.alphaTest > 0.0) {
+      gltfMaterial.alphaMode = "MASK";
+      gltfMaterial.alphaCutoff = material.alphaTest;
     }
 
     // doubleSided


### PR DESCRIPTION
This was fixed upstream in this PR and we hadn't pulled in the change yet. Probably another reason to move back to the official GLTFExporter now that a plugin system exists. https://github.com/mrdoob/three.js/pull/17433