### PR TITLE
legacyComponentName -> componentName

### DIFF
--- a/src/editor/nodes/AmbientLightNode.js
+++ b/src/editor/nodes/AmbientLightNode.js
@@ -2,7 +2,7 @@ import { AmbientLight } from "three";
 import EditorNodeMixin from "./EditorNodeMixin";
 
 export default class AmbientLightNode extends EditorNodeMixin(AmbientLight) {
-  static legacyComponentName = "ambient-light";
+  static componentName = "ambient-light";
 
   static nodeName = "Ambient Light";
 

--- a/src/editor/nodes/AudioNode.js
+++ b/src/editor/nodes/AudioNode.js
@@ -8,7 +8,7 @@ import { RethrownError } from "../utils/errors";
 let audioHelperTexture = null;
 
 export default class AudioNode extends EditorNodeMixin(AudioSource) {
-  static legacyComponentName = "audio";
+  static componentName = "audio";
 
   static nodeName = "Audio";
 

--- a/src/editor/nodes/BoxColliderNode.js
+++ b/src/editor/nodes/BoxColliderNode.js
@@ -2,7 +2,7 @@ import { Object3D, BoxBufferGeometry, Material, Mesh, BoxHelper } from "three";
 import EditorNodeMixin from "./EditorNodeMixin";
 
 export default class BoxColliderNode extends EditorNodeMixin(Object3D) {
-  static legacyComponentName = "box-collider";
+  static componentName = "box-collider";
 
   static nodeName = "Box Collider";
 

--- a/src/editor/nodes/DirectionalLightNode.js
+++ b/src/editor/nodes/DirectionalLightNode.js
@@ -3,7 +3,7 @@ import PhysicalDirectionalLight from "../objects/PhysicalDirectionalLight";
 import SpokeDirectionalLightHelper from "../helpers/SpokeDirectionalLightHelper";
 
 export default class DirectionalLightNode extends EditorNodeMixin(PhysicalDirectionalLight) {
-  static legacyComponentName = "directional-light";
+  static componentName = "directional-light";
 
   static nodeName = "Directional Light";
 

--- a/src/editor/nodes/EditorNodeMixin.js
+++ b/src/editor/nodes/EditorNodeMixin.js
@@ -36,7 +36,7 @@ export default function EditorNodeMixin(Object3DClass) {
     }
 
     static shouldDeserialize(entityJson) {
-      return !!entityJson.components.find(c => c.name === this.legacyComponentName);
+      return !!entityJson.components.find(c => c.name === this.componentName);
     }
 
     static async deserialize(editor, json) {

--- a/src/editor/nodes/FloorPlanNode.js
+++ b/src/editor/nodes/FloorPlanNode.js
@@ -23,7 +23,7 @@ export const NavMeshMode = {
 export default class FloorPlanNode extends EditorNodeMixin(FloorPlan) {
   static nodeName = "Floor Plan";
 
-  static legacyComponentName = "floor-plan";
+  static componentName = "floor-plan";
 
   static disableTransform = true;
 

--- a/src/editor/nodes/GroundPlaneNode.js
+++ b/src/editor/nodes/GroundPlaneNode.js
@@ -3,7 +3,7 @@ import EditorNodeMixin from "./EditorNodeMixin";
 import GroundPlane from "../objects/GroundPlane";
 
 export default class GroundPlaneNode extends EditorNodeMixin(GroundPlane) {
-  static legacyComponentName = "ground-plane";
+  static componentName = "ground-plane";
 
   static nodeName = "Ground Plane";
 

--- a/src/editor/nodes/GroupNode.js
+++ b/src/editor/nodes/GroupNode.js
@@ -2,7 +2,7 @@ import { Group } from "three";
 import EditorNodeMixin from "./EditorNodeMixin";
 
 export default class GroupNode extends EditorNodeMixin(Group) {
-  static legacyComponentName = "group";
+  static componentName = "group";
 
   static nodeName = "Group";
 

--- a/src/editor/nodes/HemisphereLightNode.js
+++ b/src/editor/nodes/HemisphereLightNode.js
@@ -2,7 +2,7 @@ import EditorNodeMixin from "./EditorNodeMixin";
 import PhysicalHemisphereLight from "../objects/PhysicalHemisphereLight";
 
 export default class HemisphereLightNode extends EditorNodeMixin(PhysicalHemisphereLight) {
-  static legacyComponentName = "hemisphere-light";
+  static componentName = "hemisphere-light";
 
   static disableTransform = true;
 

--- a/src/editor/nodes/ImageNode.js
+++ b/src/editor/nodes/ImageNode.js
@@ -5,7 +5,7 @@ import { RethrownError } from "../utils/errors";
 import { getObjectPerfIssues, maybeAddLargeFileIssue } from "../utils/performance";
 
 export default class ImageNode extends EditorNodeMixin(Image) {
-  static legacyComponentName = "image";
+  static componentName = "image";
 
   static nodeName = "Image";
 

--- a/src/editor/nodes/KitPieceNode.js
+++ b/src/editor/nodes/KitPieceNode.js
@@ -8,7 +8,7 @@ import { isKitPieceNode, getComponent, getGLTFComponent, traverseGltfNode } from
 import { RethrownError } from "../utils/errors";
 
 export default class KitPieceNode extends EditorNodeMixin(Model) {
-  static legacyComponentName = "kit-piece";
+  static componentName = "kit-piece";
 
   static experimental = true;
 

--- a/src/editor/nodes/LinkNode.js
+++ b/src/editor/nodes/LinkNode.js
@@ -6,7 +6,7 @@ import loadTexture from "../utils/loadTexture";
 let linkHelperTexture = null;
 
 export default class LinkNode extends EditorNodeMixin(Object3D) {
-  static legacyComponentName = "link";
+  static componentName = "link";
 
   static nodeName = "Link";
 

--- a/src/editor/nodes/MediaFrameNode.js
+++ b/src/editor/nodes/MediaFrameNode.js
@@ -20,7 +20,7 @@ export const MediaType = {
 };
 
 export default class MediaFrameNode extends EditorNodeMixin(Object3D) {
-  static legacyComponentName = "media-frame";
+  static componentName = "media-frame";
 
   static nodeName = "Media Frame";
 

--- a/src/editor/nodes/ModelNode.js
+++ b/src/editor/nodes/ModelNode.js
@@ -23,7 +23,7 @@ const defaultStats = {
 export default class ModelNode extends EditorNodeMixin(Model) {
   static nodeName = "Model";
 
-  static legacyComponentName = "gltf-model";
+  static componentName = "gltf-model";
 
   static initialElementProps = {
     initialScale: "fit",

--- a/src/editor/nodes/ParticleEmitterNode.js
+++ b/src/editor/nodes/ParticleEmitterNode.js
@@ -7,7 +7,7 @@ import loadTexture from "../utils/loadTexture";
 let defaultParticleSprite = null;
 
 export default class ParticleEmitterNode extends EditorNodeMixin(ParticleEmitter) {
-  static legacyComponentName = "particle-emitter";
+  static componentName = "particle-emitter";
 
   static nodeName = "Particle Emitter";
 

--- a/src/editor/nodes/PointLightNode.js
+++ b/src/editor/nodes/PointLightNode.js
@@ -3,7 +3,7 @@ import PhysicalPointLight from "../objects/PhysicalPointLight";
 import SpokePointLightHelper from "../helpers/SpokePointLightHelper";
 
 export default class PointLightNode extends EditorNodeMixin(PhysicalPointLight) {
-  static legacyComponentName = "point-light";
+  static componentName = "point-light";
 
   static nodeName = "Point Light";
 

--- a/src/editor/nodes/ScenePreviewCameraNode.js
+++ b/src/editor/nodes/ScenePreviewCameraNode.js
@@ -2,7 +2,7 @@ import { Matrix4, PerspectiveCamera, CameraHelper } from "three";
 import EditorNodeMixin from "./EditorNodeMixin";
 
 export default class ScenePreviewCameraNode extends EditorNodeMixin(PerspectiveCamera) {
-  static legacyComponentName = "scene-preview-camera";
+  static componentName = "scene-preview-camera";
 
   static nodeName = "Scene Preview Camera";
 

--- a/src/editor/nodes/SimpleWaterNode.js
+++ b/src/editor/nodes/SimpleWaterNode.js
@@ -7,7 +7,7 @@ import { Texture } from "three";
 let waterNormalMap = null;
 
 export default class SimpleWaterNode extends EditorNodeMixin(SimpleWater) {
-  static legacyComponentName = "simple-water";
+  static componentName = "simple-water";
 
   static nodeName = "Simple Water";
 
@@ -25,7 +25,7 @@ export default class SimpleWaterNode extends EditorNodeMixin(SimpleWater) {
       waveSpeed,
       ripplesSpeed,
       ripplesScale
-    } = json.components.find(c => c.name === SimpleWaterNode.legacyComponentName).props;
+    } = json.components.find(c => c.name === SimpleWaterNode.componentName).props;
 
     node.opacity = opacity;
     node.color.set(color);

--- a/src/editor/nodes/SkyboxNode.js
+++ b/src/editor/nodes/SkyboxNode.js
@@ -2,7 +2,7 @@ import EditorNodeMixin from "./EditorNodeMixin";
 import Sky from "../objects/Sky";
 
 export default class SkyboxNode extends EditorNodeMixin(Sky) {
-  static legacyComponentName = "skybox";
+  static componentName = "skybox";
 
   static disableTransform = true;
 

--- a/src/editor/nodes/SpawnPointNode.js
+++ b/src/editor/nodes/SpawnPointNode.js
@@ -6,7 +6,7 @@ import spawnPointModelUrl from "../../assets/spawn-point.glb";
 let spawnPointHelperModel = null;
 
 export default class SpawnPointNode extends EditorNodeMixin(Object3D) {
-  static legacyComponentName = "spawn-point";
+  static componentName = "spawn-point";
 
   static nodeName = "Spawn Point";
 

--- a/src/editor/nodes/SpawnerNode.js
+++ b/src/editor/nodes/SpawnerNode.js
@@ -20,7 +20,7 @@ const defaultStats = {
 };
 
 export default class SpawnerNode extends EditorNodeMixin(Model) {
-  static legacyComponentName = "spawner";
+  static componentName = "spawner";
 
   static nodeName = "Spawner";
 

--- a/src/editor/nodes/SpotLightNode.js
+++ b/src/editor/nodes/SpotLightNode.js
@@ -3,7 +3,7 @@ import PhysicalSpotLight from "../objects/PhysicalSpotLight";
 import SpokeSpotLightHelper from "../helpers/SpokeSpotLightHelper";
 
 export default class SpotLightNode extends EditorNodeMixin(PhysicalSpotLight) {
-  static legacyComponentName = "spot-light";
+  static componentName = "spot-light";
 
   static nodeName = "Spot Light";
 

--- a/src/editor/nodes/TriggerVolumeNode.js
+++ b/src/editor/nodes/TriggerVolumeNode.js
@@ -12,7 +12,7 @@ const requiredProperties = [
 ];
 
 export default class TriggerVolumeNode extends EditorNodeMixin(Object3D) {
-  static legacyComponentName = "trigger-volume";
+  static componentName = "trigger-volume";
 
   static experimental = true;
 

--- a/src/editor/nodes/VideoNode.js
+++ b/src/editor/nodes/VideoNode.js
@@ -7,7 +7,7 @@ import { RethrownError } from "../utils/errors";
 import { getObjectPerfIssues } from "../utils/performance";
 
 export default class VideoNode extends EditorNodeMixin(Video) {
-  static legacyComponentName = "video";
+  static componentName = "video";
 
   static nodeName = "Video";
 

--- a/src/editor/nodes/WayPointNode.js
+++ b/src/editor/nodes/WayPointNode.js
@@ -6,7 +6,7 @@ import wayPointModelUrl from "../../assets/spawn-point.glb";
 let wayPointHelperModel = null;
 
 export default class WayPointNode extends EditorNodeMixin(Object3D) {
-  static legacyComponentName = "waypoint";
+  static componentName = "waypoint";
 
   static nodeName = "Way Point";
 


### PR DESCRIPTION
I originally thought we'd completely move over to an ECS data structure in Spoke, but that hasn't been the case. The serialization format uses it, but Nodes are still OOP. This changes the property `legacyComponentName` to `componentName` to indicate the fact that this is in-fact the current way of doing things.