### PR TITLE
Refactor GroupNodeEditor

### DIFF
--- a/src/ui/properties/GroupNodeEditor.js
+++ b/src/ui/properties/GroupNodeEditor.js
@@ -1,20 +1,12 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
+import React from "react";
 import NodeEditor from "./NodeEditor";
 import { Cubes } from "styled-icons/fa-solid/Cubes";
 
-export default class GroupNodeEditor extends Component {
-  static propTypes = {
-    editor: PropTypes.object,
-    node: PropTypes.object
-  };
-
-  static iconComponent = Cubes;
-
-  static description =
-    "A group of multiple objects that can be moved or duplicated together.\nDrag and drop objects into the Group in the Hierarchy.";
-
-  render() {
-    return <NodeEditor {...this.props} description={GroupNodeEditor.description} />;
-  }
+export default function GroupNodeEditor(props) {
+  return <NodeEditor {...props} description={GroupNodeEditor.description} />;
 }
+
+GroupNodeEditor.iconComponent = Cubes;
+
+GroupNodeEditor.description =
+  "A group of multiple objects that can be moved or duplicated together.\nDrag and drop objects into the Group in the Hierarchy.";


### PR DESCRIPTION
This PR moves the GroupNodeEditor to a functional component. In the new contributor guide I'd like to use the Group Node as an example and have it using the most recent best practices.