### PR TITLE
Make Spoke controls link to the Hubs docs instead of Spoke wiki

### DIFF
--- a/src/ui/EditorContainer.js
+++ b/src/ui/EditorContainer.js
@@ -389,7 +389,7 @@ class EditorContainer extends Component {
           },
           {
             name: "Keyboard and Mouse Controls",
-            action: () => window.open("https://github.com/mozilla/Spoke/wiki/Keyboard-and-Mouse-Controls")
+            action: () => window.open("https://hubs.mozilla.com/docs/spoke-controls.html")
           },
           {
             name: "Get Support",


### PR DESCRIPTION
I'd like to remove the wiki since it's not up to date anymore. We'll use the docs site instead.