### PR TITLE
Allow passing through components with node refferences

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -423,30 +423,8 @@ export default class Editor extends EventEmitter {
         }
       }
 
-      for (const nodeDef of nodeDefs) {
-        if (nodeDef.extensions && nodeDef.extensions.MOZ_hubs_components) {
-          const components = nodeDef.extensions.MOZ_hubs_components;
-          for (const componentName in components) {
-            if (!Object.prototype.hasOwnProperty.call(components, componentName)) continue;
-
-            const component = components[componentName];
-
-            for (const propertyName in component) {
-              if (!Object.prototype.hasOwnProperty.call(component, propertyName)) continue;
-
-              const property = component[propertyName];
-
-              if (
-                property !== null &&
-                typeof property === "object" &&
-                Object.prototype.hasOwnProperty.call(property, "__gltfIndexForUUID")
-              ) {
-                component[propertyName] = uuidToIndexMap[property.__gltfIndexForUUID];
-              }
-            }
-          }
-        }
-      }
+      this.remapNodeRefsInComponents(json.nodes, nodeDefs, uuidToIndexMap);
+      this.remapNodeRefsInComponents(json.materials, nodeDefs, uuidToIndexMap);
     }
 
     if (!json.extensions) {
@@ -473,6 +451,33 @@ export default class Editor extends EventEmitter {
       return { glbBlob, chunks, scores };
     } catch (error) {
       throw new RethrownError("Error creating glb blob", error);
+    }
+  }
+
+  remapNodeRefsInComponents(collection, nodeDefs, uuidToIndexMap) {
+    for (const def of collection) {
+      if (def.extensions && def.extensions.MOZ_hubs_components) {
+        const components = def.extensions.MOZ_hubs_components;
+        for (const componentName in components) {
+          if (!Object.prototype.hasOwnProperty.call(components, componentName)) continue;
+
+          const component = components[componentName];
+
+          for (const propertyName in component) {
+            if (!Object.prototype.hasOwnProperty.call(component, propertyName)) continue;
+
+            const property = component[propertyName];
+
+            if (
+              property !== null &&
+              typeof property === "object" &&
+              Object.prototype.hasOwnProperty.call(property, "__gltfIndexForUUID")
+            ) {
+              component[propertyName] = uuidToIndexMap[property.__gltfIndexForUUID];
+            }
+          }
+        }
+      }
     }
   }
 

--- a/src/editor/gltf/GLTFExporter.js
+++ b/src/editor/gltf/GLTFExporter.js
@@ -1262,6 +1262,47 @@ class GLTFExporter {
   }
 
   /**
+   * Process camera
+   * @param  {THREE.Camera} camera Camera to process
+   * @return {Integer}      Index of the processed mesh in the "camera" array
+   */
+  processCamera(camera) {
+    if (!this.outputJSON.cameras) {
+      this.outputJSON.cameras = [];
+    }
+
+    const isOrtho = camera.isOrthographicCamera;
+
+    const gltfCamera = {
+      type: isOrtho ? "orthographic" : "perspective"
+    };
+
+    if (isOrtho) {
+      gltfCamera.orthographic = {
+        xmag: camera.right * 2,
+        ymag: camera.top * 2,
+        zfar: camera.far <= 0 ? 0.001 : camera.far,
+        znear: camera.near < 0 ? 0 : camera.near
+      };
+    } else {
+      gltfCamera.perspective = {
+        aspectRatio: camera.aspect,
+        yfov: _Math.degToRad(camera.fov),
+        zfar: camera.far <= 0 ? 0.001 : camera.far,
+        znear: camera.near < 0 ? 0 : camera.near
+      };
+    }
+
+    if (camera.name !== "") {
+      gltfCamera.name = camera.type;
+    }
+
+    this.outputJSON.cameras.push(gltfCamera);
+
+    return this.outputJSON.cameras.length - 1;
+  }
+
+  /**
    * Process Object3D node
    * @param  {THREE.Object3D} node Object3D to processNode
    * @return {Integer}      Index of the node in the nodes list
@@ -1312,6 +1353,8 @@ class GLTFExporter {
       if (mesh !== null) {
         gltfNode.mesh = mesh;
       }
+    } else if (object.isCamera) {
+      gltfNode.camera = this.processCamera(object);
     }
 
     if (object.isSkinnedMesh) {

--- a/src/editor/gltf/GLTFLoader.js
+++ b/src/editor/gltf/GLTFLoader.js
@@ -14,6 +14,7 @@
 
 import { RethrownError } from "../utils/errors";
 import loadTexture from "../utils/loadTexture";
+import { HUBS_NODEREF_COMPONENTS, getComponents } from "./moz-hubs-components";
 
 import {
   AnimationClip,
@@ -191,11 +192,6 @@ const EXTENSIONS = {
 const GLB_HEADER_MAGIC = "glTF";
 const GLB_HEADER_LENGTH = 12;
 const GLB_CHUNK_TYPES = { JSON: 0x4e4f534a, BIN: 0x004e4942 };
-
-const HUBS_NODEREF_COMPONENTS = {
-  "video-texture-target": ["srcNode"],
-  "trigger-volume": ["target"]
-};
 
 /*********************************/
 /********** INTERPOLATION ********/
@@ -1996,7 +1992,7 @@ class GLTFLoader {
         object.userData.gltfExtensions = object.userData.gltfExtensions || {};
         object.userData.gltfExtensions[name] = objectDef.extensions[name];
         if (name === "MOZ_hubs_components") {
-          const components = object.userData.gltfExtensions[name];
+          const components = getComponents(object);
           for (const [componentName, componentProps] of Object.entries(components)) {
             for (const [propName, propValue] of Object.entries(componentProps)) {
               if (

--- a/src/editor/gltf/moz-hubs-components.js
+++ b/src/editor/gltf/moz-hubs-components.js
@@ -1,5 +1,12 @@
 import findObject from "../utils/findObject";
 
+// Component prooperties that contain node references
+// TODO these should be part of any sort of larger component schema efforts
+export const HUBS_NODEREF_COMPONENTS = {
+  "video-texture-target": ["srcNode"],
+  "trigger-volume": ["target"]
+};
+
 export function getComponents(object) {
   return (
     object.userData.gltfExtensions &&


### PR DESCRIPTION
This adds support for importing GLTFs that contain Hubs components with node references. The GLTF index in values of specific components (defined in `HUBS_NODEREF_COMPONENTS` for now) is remapped to a UUID of the target node at import time. At export time this value is remapped back to the index of the same node in the final exported GLTF. This piggybacks on the existing method used in Spoke for exporting these references.  We should be able to apply a similar technique for other sorts of internal references (materials, images, etc) as needed. We plan to replace the GLTFLoader/GLTFExporter soon but this should be easily ported to the new plugin API.

Separately, also allows the GLTF exporter to export cameras so they are correctly passed through.

These are both used in the new `video-texture-target`/`video-texture-soruce` components https://github.com/mozilla/hubs/pull/4126