### PR TITLE
Add audio-target.srcNode to nodeRef components

### DIFF
--- a/src/editor/gltf/moz-hubs-components.js
+++ b/src/editor/gltf/moz-hubs-components.js
@@ -4,6 +4,7 @@ import findObject from "../utils/findObject";
 // TODO these should be part of any sort of larger component schema efforts
 export const HUBS_NODEREF_COMPONENTS = {
   "video-texture-target": ["srcNode"],
+  "audio-target": ["srcNode"],
   "trigger-volume": ["target"]
 };
 


### PR DESCRIPTION
This allows `audio-target`s to correctly pass through Spoke