### PR TITLE
Change `onloadeddata` to `oncanplay`

### DIFF
--- a/src/editor/utils/thumbnails.js
+++ b/src/editor/utils/thumbnails.js
@@ -36,7 +36,7 @@ export async function generateVideoFileThumbnail(file, width, height, background
   const video = document.createElement("video");
   await new Promise((resolve, reject) => {
     video.src = url;
-    video.onloadeddata = resolve;
+    video.oncanplay = resolve;
     video.onerror = reject;
   });
   URL.revokeObjectURL(url);


### PR DESCRIPTION
Due to an obscure timing issue with HTML5Video in certain browsers, i.e. Chrome, `video.onloadeddata` can fire a split-second before the data is _actually_ ready. In this chunk of code, this can occasionally cause certain video files (I believe it to be some HD video files, specifically) to fail to upload during thumbnail generation with the error "file not found" because the blobbed URL is sometimes revoked too quickly. This was an issue my team ran into with a high resolution video (2048x1024, ~50MB).

I'm not sure if replacing `onloadeddata` with `oncanplay` is the _best_ solution, but it did fix the problem we were having, since the video now relies on being able to start video playback before revoking the data URL.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/HUBS-1110)
