### PR TITLE
Restore lost media params

### DIFF
--- a/src/ui/properties/AudioNodeEditor.js
+++ b/src/ui/properties/AudioNodeEditor.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import NodeEditor from "./NodeEditor";
 import InputGroup from "../inputs/InputGroup";
 import AudioInput from "../inputs/AudioInput";
+import BooleanInput from "../inputs/BooleanInput";
 import { VolumeUp } from "styled-icons/fa-solid/VolumeUp";
 import AudioParamsProperties from "./AudioParamsProperties";
 import useSetPropertySelected from "./useSetPropertySelected";
@@ -10,11 +11,23 @@ import useSetPropertySelected from "./useSetPropertySelected";
 export default function AudioNodeEditor(props) {
   const { editor, node } = props;
   const onChangeSrc = useSetPropertySelected(editor, "src");
+  const onChangeControls = useSetPropertySelected(editor, "controls");
+  const onChangeAutoPlay = useSetPropertySelected(editor, "autoPlay");
+  const onChangeLoop = useSetPropertySelected(editor, "loop");
 
   return (
     <NodeEditor description={AudioNodeEditor.description} {...props}>
       <InputGroup name="Audio Url">
         <AudioInput value={node.src} onChange={onChangeSrc} />
+      </InputGroup>
+      <InputGroup name="Controls" info="Toggle the visibility of the media controls in Hubs.">
+        <BooleanInput value={node.controls} onChange={onChangeControls} />
+      </InputGroup>
+      <InputGroup name="Auto Play" info="If true, the media will play when first entering the scene.">
+        <BooleanInput value={node.autoPlay} onChange={onChangeAutoPlay} />
+      </InputGroup>
+      <InputGroup name="Loop" info="If true the media will loop indefinitely.">
+        <BooleanInput value={node.loop} onChange={onChangeLoop} />
       </InputGroup>
       <AudioParamsProperties {...props} />
     </NodeEditor>

--- a/src/ui/properties/VideoNodeEditor.js
+++ b/src/ui/properties/VideoNodeEditor.js
@@ -20,6 +20,9 @@ export default function VideoNodeEditor(props) {
   const onChangeProjection = useSetPropertySelected(editor, "projection");
   const onChangeBillboard = useSetPropertySelected(editor, "billboard");
   const onChangeHref = useSetPropertySelected(editor, "href");
+  const onChangeControls = useSetPropertySelected(editor, "controls");
+  const onChangeAutoPlay = useSetPropertySelected(editor, "autoPlay");
+  const onChangeLoop = useSetPropertySelected(editor, "loop");
 
   return (
     <NodeEditor description={VideoNodeEditor.description} {...props}>
@@ -36,6 +39,15 @@ export default function VideoNodeEditor(props) {
       )}
       <InputGroup name="Projection">
         <SelectInput options={videoProjectionOptions} value={node.projection} onChange={onChangeProjection} />
+      </InputGroup>
+      <InputGroup name="Controls" info="Toggle the visibility of the media controls in Hubs.">
+        <BooleanInput value={node.controls} onChange={onChangeControls} />
+      </InputGroup>
+      <InputGroup name="Auto Play" info="If true, the media will play when first entering the scene.">
+        <BooleanInput value={node.autoPlay} onChange={onChangeAutoPlay} />
+      </InputGroup>
+      <InputGroup name="Loop" info="If true the media will loop indefinitely.">
+        <BooleanInput value={node.loop} onChange={onChangeLoop} />
       </InputGroup>
       <AudioParamsProperties {...props} />
       <AttributionNodeEditor name="Attribution" {...props} />


### PR DESCRIPTION
During the Audio zones PR some media properties were accidentally removed from the audio and video nodes.

This PR restores those params

Fixes https://github.com/mozilla/Spoke/issues/1160