### PR TITLE
Add dockerfile, scripts, and github workflow for Turkey ops

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+node_modules

--- a/.github/workflows/spoke-RetPageOrigin.yml
+++ b/.github/workflows/spoke-RetPageOrigin.yml
@@ -1,0 +1,15 @@
+name: spoke
+on:
+  push:
+    branches:
+    paths-ignore: ["README.md"]
+  workflow_dispatch:
+
+jobs:
+  turkeyGitops:
+    uses: mozilla/hubs-ops/.github/workflows/turkeyGitops.yml@master
+    with:
+      registry: mozillareality
+      dockerfile: RetPageOriginDockerfile
+    secrets:
+      DOCKER_HUB_PWD: ${{ secrets.DOCKER_HUB_PWD }}

--- a/RetPageOriginDockerfile
+++ b/RetPageOriginDockerfile
@@ -1,0 +1,30 @@
+###
+# this dockerfile produces image/container that serves customly packaged spoke static files
+# the result container should serve reticulum as "spoke_page_origin" on (path) "/spoke/pages"
+###
+from node:16.13 as builder
+run mkdir /spoke && cd /spoke
+copy package.json ./
+copy yarn.lock ./
+run yarn install --frozen-lockfile
+copy . .
+env BASE_ASSETS_PATH="{{rawspoke-base-assets-path}}"
+# TODO we should be setting BUILD_VERSION, probably pass in git sha or run number as an ARG
+run yarn build 1> /dev/null
+run mkdir -p dist/pages && mv dist/*.html dist/pages
+# TODO can't we just move this directly from dist to /www ?
+run mkdir /spoke/rawspoke && mv dist/pages /spoke/rawspoke && mv dist/assets /spoke/rawspoke
+
+from alpine/openssl as ssl
+run mkdir /ssl && openssl req -x509 -newkey rsa:2048 -sha256 -days 36500 -nodes -keyout /ssl/key -out /ssl/cert -subj '/CN=spoke'
+
+from nginx:alpine
+run apk add bash
+run mkdir /ssl && mkdir -p /www/spoke && mkdir -p /www/spoke/pages && mkdir -p /www/spoke/assets
+copy --from=ssl /ssl /ssl
+copy --from=builder /spoke/rawspoke/pages /www/spoke/pages
+copy --from=builder /spoke/rawspoke/assets /www/spoke/assets
+copy scripts/docker/nginx.config /etc/nginx/conf.d/default.conf
+copy scripts/docker/run.sh /run.sh
+run chmod +x /run.sh && cat /run.sh
+cmd bash /run.sh

--- a/scripts/docker/nginx.config
+++ b/scripts/docker/nginx.config
@@ -1,0 +1,10 @@
+server {
+    listen 8080 ssl;
+    ssl_certificate /ssl/cert;
+    ssl_certificate_key /ssl/key;
+    location / {
+        root /www;
+        autoindex off;
+        add_header 'Access-Control-Allow-Origin' '*';
+    }
+}

--- a/scripts/docker/run.sh
+++ b/scripts/docker/run.sh
@@ -1,0 +1,13 @@
+find /www/spoke/ -type f -name *.html -exec sed -i "s/{{rawspoke-base-assets-path}}\//${turkeyCfg_base_assets_path}/g" {} \;
+find /www/spoke/ -type f -name *.html -exec sed -i "s/{{rawspoke-base-assets-path}}/${turkeyCfg_base_assets_path}/g" {} \;
+find /www/spoke/ -type f -name *.css -exec sed -i "s/{{rawspoke-base-assets-path}}\//${turkeyCfg_base_assets_path}/g" {} \;
+find /www/spoke/ -type f -name *.css -exec sed -i "s/{{rawspoke-base-assets-path}}/${turkeyCfg_base_assets_path}/g" {} \;
+
+anchor="<!-- DO NOT REMOVE\/EDIT THIS COMMENT - META_TAGS -->"
+for f in /www/spoke/pages/*.html; do
+    for var in $(printenv); do
+    var=$(echo $var | cut -d"=" -f1 ); prefix="turkeyCfg_";
+    [[ $var == $prefix* ]] && sed -i "s/$anchor/ <meta name=\"env:${var#$prefix}\" content=\"${!var//\//\\\/}\"\/> $anchor/" $f;
+    done
+done
+nginx -g "daemon off;"


### PR DESCRIPTION
This is essentially exactly the same as Hubs, except Spoke uses yarn instead of npm.

I used `turkeyCfg_base_asset_path` instead of constructing a url from `DOMAIN` and `SUB_DOMAIN` as that seems more correct. If there wasn't a reason for this we should do this in Hubs as well.

I noticed in the Hubs run.sh we have a sort of fake http server for liveness/readyness checks. Any reason not to just request index.html from the actual nginx server? Simpler and actually represents the health of the pod.

I have only tested this insofar as the substitution in index.html looks sane and nginx serves it up on the expected port/path. Still need to try actually pointing a reticulum at it.