### PR TITLE
Fix `creating-custom-elements` example

### DIFF
--- a/docs/creating-custom-elements.md
+++ b/docs/creating-custom-elements.md
@@ -35,7 +35,7 @@ The constructor will be the constructor for the `Object3D` that we are applying 
 
 We'll stop there for now with the node class and move onto the node editor.
 
-Create a new file, `SpinningCubeEditor` in `src/ui/properties`.
+Create a new file, `SpinningCubeNodeEditor` in `src/ui/properties`.
 
 This file will be a React component that should use the `<NodeEditor>` component as it's root element. The rest of the editor properties will be added as children of this element.
 


### PR DESCRIPTION
# Doing

- Line 38: `SpinningCubeEditor` -> `SpinningCubeNodeEditor`

# Why

- When I following the example in 'docs/creating-custom-elements` I meet the error
  ![image](https://user-images.githubusercontent.com/41536271/149447529-43910d81-6c32-4864-b9e5-0aacaa150920.png)
- Example wrote the `SpinningCubeEditor`. but, should write `SpinningCubeNodeEditor`