### PR TITLE
Specify keySize for selfsigned certs

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,6 +38,7 @@ function createHTTPSConfig() {
       {
         days: 365,
         algorithm: "sha256",
+        keySize: 2048,
         extensions: [
           {
             name: "subjectAltName",


### PR DESCRIPTION
The `selfsigned` library uses a default key size of 1024. Depending on the system's openssl configuration, this can lead to the following error, preventing Spoke from starting:
```
Error: error:140AB18F:SSL routines:SSL_CTX_use_certificate:ee key too small
```

It's a known issue with `selfsigned` (see https://github.com/jfromaniello/selfsigned/issues/33), but until they increase the default keySize, specifying it in the `webpack.config.js` file resolves this issue as well.