### PR TITLE
downloading material package times out in hab pkg build

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+network-timeout 600000


### PR DESCRIPTION
Running `hab pkg build .` is having timeout issues when downloading "@icons/material@^0.2.4". This repo has 90000+ files to extract possibly which takes quite a long time. There is a smaller version of the repo offered which might make this an unnecessary addition. 