### PR TITLE
Fix publishing scenes with no models i.e. the e is not iterable error.

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -424,7 +424,11 @@ export default class Editor extends EventEmitter {
       }
 
       this.remapNodeRefsInComponents(json.nodes, nodeDefs, uuidToIndexMap);
-      this.remapNodeRefsInComponents(json.materials, nodeDefs, uuidToIndexMap);
+
+      // Account for scenes that don't contain any geometry/materials.
+      if (json.materials !== undefined) {
+        this.remapNodeRefsInComponents(json.materials, nodeDefs, uuidToIndexMap);
+      }
     }
 
     if (!json.extensions) {

--- a/src/editor/gltf/GLTFExporter.js
+++ b/src/editor/gltf/GLTFExporter.js
@@ -1588,6 +1588,9 @@ class GLTFExporter {
       });
 
       pending.push(pendingBinChunk);
+    } else {
+      const totalByteLength = GLB_HEADER_BYTES + jsonChunkPrefix.byteLength + jsonChunk.byteLength;
+      headerView.setUint32(8, totalByteLength, true);
     }
 
     await Promise.all(pending);


### PR DESCRIPTION
Fixes #1137
Skip trying to remap the node refs for materials if there aren't any materials in the scene. Add the length of the JSON chunk to the header when there is no binary buffer so that a valid GLB file can be generated.